### PR TITLE
Bootstrap updates for Phase 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,10 @@ DB_HOST=localhost
 DB_PORT=3306
 DB_USER=nucleus
 DB_PASS=secret
+NUCLEUS_AUTH_CLIENT_ID=local-client
+NUCLEUS_AUTH_SECRET=supersecretkey
+IMAP_HOST=mail.example.com
+IMAP_PORT=993
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Refer to [CRM/README.md](CRM/README.md) for full documentation.
 See readme.md for Directus upstream instructions.
 Detailed feature inventory lives in docs/inventory.md.
 
+Copy `.env.example` to `.env` and adjust values before running `scripts/install.sh`.
+
 ## Testing the GUI
 
 Run `scripts/gui_loop.sh` to install dependencies, launch the services and

--- a/agents.md
+++ b/agents.md
@@ -1,8 +1,14 @@
 # Codex Agent Instructions
 
-Follow the closed-loop process for updates. Document actions in `changelog.md` and pending tasks in `todo.md`.
+The Nucleus CRM project uses a strict closed-loop workflow.
+Agents must:
 
-# Agents
+1. Record every code change in `changelog.md` with a numbered pass.
+2. Track unresolved items in `todo.md`.
+3. Run `npm test` whenever dependencies or code change.
 
-This repository follows a closed loop development process. All features are tested via CLI and GUI as described in CRM/AGENTS.md.
+Governance rules forbid touching upstream Directus code outside the `CRM/` and `extensions/` directories.
+Current prompt roles: **system**, **developer**, **user**.
+
+For detailed CLI↔GUI mapping see `CRM/AGENTS.md`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,13 @@
 - Pass 09 - Updated TODO
 - Pass 10 - Workspace bootstrap complete
 
+## Phase 2 (continued)
+- Pass 11 - Added environment variables and expanded install script
+- Pass 12 - Documented module layout and auth flow
+- Pass 13 - Declared agent governance rules
+- Pass 14 - Updated TODO list for upcoming modules
+- Pass 15 - Documented env setup in README
+
 
 ## Docs and Scripts Update
 - Date: 2025-07-07

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,17 @@ The platform consists of a React frontend, a FastAPI backend and a Node.js servi
 Data is stored in a SQL database. External integrations like Sophos, Tenable and DMARC analyzer run as separate workers.
 Extensions live under /extensions and are loaded by Directus.
 
+## Module Layout
+
+```
+CRM/                # CRM specific React and FastAPI modules
+extensions/         # Directus extensions (endpoints, hooks, interfaces)
+scripts/            # Helper CLI scripts and installers
+docs/               # User and developer documentation
+```
+
+Each extension can be enabled or disabled independently so deployments can remain lightweight.
+
 ## Integration Points
 
 The CRM hooks into Directus only via supported extension mechanisms. Custom
@@ -18,4 +29,12 @@ The FastAPI backend exposes REST endpoints such as `/health` that Directus and
 external services consume. The Node authentication service manages OTP login and
 redirects users back to `/core/<role>` dashboards. CLI scripts under
 `CRM/scripts/` mirror GUI operations as documented in `CRM/AGENTS.md`.
+
+## Planned Authentication Flow
+
+1. Users visit `/auth/login` served by the Node.js service.
+2. Credentials and OTP tokens are validated against the FastAPI backend.
+3. Upon success, the backend issues a signed JWT using `NUCLEUS_AUTH_SECRET` from the environment.
+4. The JWT is stored in a Directus session and the user is redirected to the CRM dashboard.
+5. Failed logins are logged to `/var/log/nucleus/auth.log` for review.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,27 @@
 
-#!/bin/sh
-# Install Directus CRM extensions
+#!/bin/bash
+# Install Directus CRM extensions and register local modules
 
 set -e
 
-echo "Installing dependencies..."
-pnpm install --silent
+LOG_DIR=/var/log/nucleus
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/install.log"
 
-echo "Setup complete." 
+# Load environment values if present
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+echo "Installing dependencies..." | tee "$LOG_FILE"
+pnpm install --silent >> "$LOG_FILE" 2>&1
+
+for EXT in extensions/*; do
+  if [ -d "$EXT" ]; then
+    echo "Registering extension $EXT" | tee -a "$LOG_FILE"
+    npx directus extension install "$EXT" >> "$LOG_FILE" 2>&1 || true
+  fi
+done
+
+echo "Setup complete." | tee -a "$LOG_FILE"
 

--- a/todo.md
+++ b/todo.md
@@ -10,3 +10,6 @@
 - [x] Commit second revision to satisfy two-loop requirement
 - [x] Document updates in `changelog.md`
 - [ ] Review inventory for completeness in Pass 02
+- [ ] Create nucleus-auth schema for authentication tables
+- [ ] Register each CRM extension in install.sh
+- [ ] Add CI pipeline to run npm and vitest


### PR DESCRIPTION
## Summary
- extend `.env.example` with auth and mail values
- expand install script with extension registration and logging
- refine architecture document with module layout and auth flow
- clarify Codex agent rules
- document env setup in README and update TODO
- add new Phase 2 changelog entries

## Testing
- `npm test` *(fails: Unsupported environment - requires Node 22)*

------
https://chatgpt.com/codex/tasks/task_e_686c19f9b1688324995c7a18bee7d806