### PR TITLE
Phase 1 pass06 resolve extensions sdk tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,3 +88,18 @@
 - Enabled pnpm through corepack
 - `npm test` still fails missing `@directus/random`
 - Documented in `loops/fix-phase1-pass02.md`
+## Phase 1 – Pass 04 (2025-07-07)
+- Installed Node.js 22 via NodeSource and activated system version with nvm.
+- Ran `pnpm install`; `npm test` fails due to missing `@directus/random`.
+- Logged issue in `loops/fix-phase1-pass03.md`.
+- Verified `/docs/inventory.md` against `/CRM/README.md`; now at Pass 04 with 19 features mapped.
+## Phase 1 – Pass 05 (2025-07-07)
+- Used `nvm` to switch to Node 22.17.
+- Built `@directus/random` with `pnpm --filter @directus/random run build` before running tests.
+- `npm test` executes without missing module errors.
+## Phase 1 – Pass 06 (2025-07-07)
+- Installed Node.js 22.17 and enabled pnpm.
+- Rebuilt random and storage packages.
+- `npm test` now completes `@directus/extensions-sdk` tests successfully.
+- Tests fail later in `@directus/app` with exit status 129, logged in `loops/fix-phase1-pass05.md`.
+

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD013 -->
-# Nucleus CRM – Inventory (Pass 02)
+# Nucleus CRM – Inventory (Pass 04)
 
 Extracted from: `/CRM/README.md`
 

--- a/loops/fix-phase1-pass03.md
+++ b/loops/fix-phase1-pass03.md
@@ -1,0 +1,5 @@
+# fix-phase1-pass03
+`npm test` fails after installing Node 22 and running `pnpm install`.
+Vitest cannot find `@directus/random` during package tests.
+Investigate monorepo build steps or missing dev dependencies.
+Fixed in Pass 05 by building `@directus/random` with `pnpm --filter @directus/random run build` before running tests.

--- a/loops/fix-phase1-pass04.md
+++ b/loops/fix-phase1-pass04.md
@@ -1,0 +1,4 @@
+# fix-phase1-pass04
+`npm test` still fails in `@directus/extensions-sdk` after building packages.
+The scaffold step exits with code 129 while creating temp extensions.
+Further investigation needed to resolve toolkit test failures.

--- a/loops/fix-phase1-pass05.md
+++ b/loops/fix-phase1-pass05.md
@@ -1,0 +1,4 @@
+# fix-phase1-pass05
+Installed Node.js 22.17 via nvm and rebuilt packages.
+`npm test` progresses past `@directus/extensions-sdk` after building packages, but now fails in `@directus/app` with exit status 129.
+Further investigation needed to finish core tests.

--- a/todo.md
+++ b/todo.md
@@ -15,4 +15,6 @@
 - [ ] Add CI pipeline to run npm and vitest
 
 - [x] Install Node 22 via apt using NodeSource repo
-- [ ] Resolve vitest dependency errors during npm test
+- [x] Resolve vitest dependency errors during npm test
+
+- [ ] Fix npm test failure in @directus/app (exit status 129)


### PR DESCRIPTION
## Summary
- document success running extensions-sdk tests
- log new failing package in loop file
- track todo for app test error

## Testing
- `npm test` *(fails in @directus/app with exit status 129)*

------
https://chatgpt.com/codex/tasks/task_e_686c3cb4290c83248dfe6000543d88a3