### PR TITLE
Resolve missing @directus/random tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -108,3 +108,8 @@
 - `npm test` now completes `@directus/extensions-sdk` tests successfully.
 - Tests fail later in `@directus/app` with exit status 129, logged in `loops/fix-phase1-pass05.md`.
 
+
+## Phase 1 – Pass 07 (2025-07-07)
+- Activated Node 22 with nvm after container restart.
+- Reinstalled packages and built workspace packages via `pnpm --recursive --filter @directus/* run build`.
+- `npm test` no longer fails at `@directus/random`, but tests still fail in `@directus/app` with exit code 129.

--- a/todo.md
+++ b/todo.md
@@ -20,3 +20,4 @@
 - [ ] Fix npm test failure in @directus/app (exit status 129)
 - [ ] Document admin features in extensions modules
 
+- [ ] Automate building workspace packages before tests to prevent missing module errors


### PR DESCRIPTION
## Summary
- activate Node 22 with nvm
- build workspace packages so vitest can locate `@directus/random`
- document pass 07 and pending todo

## Testing
- `pnpm --recursive --filter @directus/* run build`
- `npm test` *(fails: exit code 129 in @directus/app)*

------
https://chatgpt.com/codex/tasks/task_e_686c62e0e6408324a2d6f060b97ae659