### PR TITLE
Phase 3 pass18 node18 fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -215,3 +215,12 @@
 ## Phase 3 – Pass 17 (2025-07-08)
 - Built @directus/constants and dependent packages for Node 18.
 - Monorepo tests progress but other packages remain unresolved.
+
+
+## Phase 3 – Pass 18 (2025-07-09)
+- Ran inventory scan of CRM modules and scripts.
+- Installed `CRM/node_backend` dependencies so Jest is available.
+- `npm test` executed under Node 18 with polyfills; monorepo tests still fail due to missing vitest.
+- Node backend tests pass.
+- Logged results in trace files for pass 18.
+

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -20,3 +20,4 @@ Load the Node 18 polyfill with:
 export NODE_OPTIONS="--import=$(pwd)/scripts/fs-glob-polyfill.js"
 ```
 to provide `fs.glob` during tests.
+Jest is installed locally in CRM/node_backend via npm install

--- a/loops/refactor-node-compat.md
+++ b/loops/refactor-node-compat.md
@@ -8,3 +8,4 @@ We checked all scripts and modules under `/extensions`, `/scripts` and `/CRM` fo
 * All project modules inside `CRM` and `scripts` use CommonJS without top-level `await` or other Node 20+ syntax.
 
 To restore compatibility with Node 18, we modified `scripts/install.sh` to install and use Node.js 18 instead of 22. The package.json requirement cannot be changed due to governance rules, so tests are executed with `PNPM_IGNORE_NODE_VERSION=true` to bypass the engine check.
+- Pass 18: Installed node_backend dependencies so Jest works under Node 18.

--- a/loops/test-env-workarounds.md
+++ b/loops/test-env-workarounds.md
@@ -16,3 +16,4 @@ export NODE_OPTIONS="--import=$(pwd)/scripts/fs-glob-polyfill.js"
 ```
 
 This polyfills `fs.glob` for packages like `@directus/sdk` during tests.
+- Pass 18: run 'npm install --prefix CRM/node_backend' before tests to provide Jest.

--- a/todo.md
+++ b/todo.md
@@ -33,3 +33,4 @@
 - Implement staged update and rollback script {status:todo} {priority:low} {blocked_by:none}
 - Adapt @directus/sdk tests for Node 18 or polyfill fs.glob {status:in-progress} {priority:medium} {blocked_by:none}
 - Verify monorepo tests with Node 18 once fs.glob polyfill is added {status:in-progress} {priority:medium} {blocked_by:none}
+- Install vitest for workspace packages to run monorepo tests {status:todo} {priority:medium} {blocked_by:none}

--- a/trace.json
+++ b/trace.json
@@ -212,5 +212,22 @@
       "todo.md"
     ],
     "trigger": "build constants"
+  },
+  {
+    "phase": "phase3",
+    "pass": 18,
+    "changes": [
+      "traces/phase3_inventory_pass18.json",
+      "traces/phase3_fix_pass18.json",
+      "traces/phase3_tests_pass18.json",
+      "traces/phase3_verification_pass18.json",
+      "traces/phase3_integrity_pass18.json",
+      "changelog.md",
+      "todo.md",
+      "loops/refactor-node-compat.md",
+      "loops/test-env-workarounds.md",
+      "docs/dependencies.md"
+    ],
+    "trigger": "jest install"
   }
 ]

--- a/traces/phase3_fix_pass18.json
+++ b/traces/phase3_fix_pass18.json
@@ -1,0 +1,9 @@
+{
+  "pass": 18,
+  "timestamp": "2025-07-09T00:14Z",
+  "changes": [
+    "Installed CRM/node_backend dependencies with npm install",
+    "Executed root npm test with PNPM_IGNORE_NODE_VERSION",
+    "Node backend tests now pass"
+  ]
+}

--- a/traces/phase3_integrity_pass18.json
+++ b/traces/phase3_integrity_pass18.json
@@ -1,0 +1,6 @@
+{
+  "pass": 18,
+  "timestamp": "2025-07-09T00:14Z",
+  "core_modified": false,
+  "notes": "Only docs and trace files updated"
+}

--- a/traces/phase3_inventory_pass18.json
+++ b/traces/phase3_inventory_pass18.json
@@ -1,0 +1,20 @@
+{
+  "pass": 18,
+  "timestamp": "2025-07-09T00:14Z",
+  "modules_scanned": [
+    "CRM/extensions/nucleus-auth",
+    "CRM/extensions/nucleus-mail-ingest",
+    "scripts/install.sh",
+    "scripts/headless_check.js",
+    "scripts/gui_loop.sh",
+    "scripts/fs-glob-polyfill.js",
+    "CRM/scripts/headless_check.js",
+    "CRM/node_backend",
+    "CRM/frontend"
+  ],
+  "node20_features": [
+    "root package.json engines.node = 22",
+    "directus/package.json engines.node >=22",
+    "fs.glob polyfill indicates Node 22 feature"
+  ]
+}

--- a/traces/phase3_tests_pass18.json
+++ b/traces/phase3_tests_pass18.json
@@ -1,0 +1,8 @@
+{
+  "pass": 18,
+  "timestamp": "2025-07-09T00:14Z",
+  "results": {
+    "crm_node_backend": "passed",
+    "monorepo_tests": "failed - vitest missing"
+  }
+}

--- a/traces/phase3_verification_pass18.json
+++ b/traces/phase3_verification_pass18.json
@@ -1,0 +1,8 @@
+{
+  "pass": 18,
+  "timestamp": "2025-07-09T00:14Z",
+  "assertions": [
+    "Node backend tests run successfully on Node 18",
+    "Monorepo tests still fail due to missing vitest command"
+  ]
+}


### PR DESCRIPTION
## Summary
- log inventory of CRM modules for pass 18
- run `npm install` for `CRM/node_backend` and execute tests
- document Jest requirement and workflow updates
- track new TODO for vitest
- record trace files for phase3 pass18

## Testing
- `npm test` *(fails: vitest missing)*
- `npm test --prefix CRM/node_backend`


------
https://chatgpt.com/codex/tasks/task_e_686db281d3a08324a780e4ddbedb5878