### PR TITLE
Phase 3 pass 19 Node 18 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -224,3 +224,8 @@
 - Node backend tests pass.
 - Logged results in trace files for pass 18.
 
+
+## Phase 3 – Pass 19 (2025-07-09)
+- Inventory scan recorded Node 22 engine and fs.glob polyfill usage.
+- `scripts/install.sh` now installs CRM node_backend dependencies for Node 18.
+- Trace files for pass 19 created.

--- a/loops/refactor-node-compat.md
+++ b/loops/refactor-node-compat.md
@@ -9,3 +9,4 @@ We checked all scripts and modules under `/extensions`, `/scripts` and `/CRM` fo
 
 To restore compatibility with Node 18, we modified `scripts/install.sh` to install and use Node.js 18 instead of 22. The package.json requirement cannot be changed due to governance rules, so tests are executed with `PNPM_IGNORE_NODE_VERSION=true` to bypass the engine check.
 - Pass 18: Installed node_backend dependencies so Jest works under Node 18.
+- Pass 19: install.sh now installs CRM node_backend dependencies

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,12 @@ fi
 echo "Installing dependencies..." | tee "$LOG_FILE"
 pnpm install --silent >> "$LOG_FILE" 2>&1
 
+# Install node_backend dependencies for tests
+if [ -d CRM/node_backend ]; then
+  echo "Installing CRM node_backend dependencies" | tee -a "$LOG_FILE"
+  npm install --prefix CRM/node_backend --silent >> "$LOG_FILE" 2>&1
+fi
+
 for EXT in extensions/*; do
   if [ -d "$EXT" ]; then
     echo "Registering extension $EXT" | tee -a "$LOG_FILE"

--- a/traces/phase3_fix_pass19.json
+++ b/traces/phase3_fix_pass19.json
@@ -1,0 +1,7 @@
+{
+  "pass": 19,
+  "timestamp": "2025-07-09T09:38Z",
+  "changes": [
+    "Added npm install step for CRM/node_backend in scripts/install.sh"
+  ]
+}

--- a/traces/phase3_integrity_pass19.json
+++ b/traces/phase3_integrity_pass19.json
@@ -1,0 +1,6 @@
+{
+  "pass": 19,
+  "timestamp": "2025-07-09T09:39Z",
+  "core_modified": false,
+  "notes": "Modified scripts and docs only"
+}

--- a/traces/phase3_inventory_pass19.json
+++ b/traces/phase3_inventory_pass19.json
@@ -1,0 +1,18 @@
+{
+  "pass": 19,
+  "timestamp": "2025-07-09T09:37Z",
+  "modules_scanned": [
+    "scripts/install.sh",
+    "scripts/gui_loop.sh",
+    "scripts/headless_check.js",
+    "scripts/fs-glob-polyfill.js",
+    "CRM/extensions/nucleus-auth",
+    "CRM/extensions/nucleus-mail-ingest",
+    "CRM/scripts/*",
+    "CRM/node_backend"
+  ],
+  "node20_features": [
+    "root .nvmrc specifies Node 22",
+    "fs.glob polyfill required for Node 18"
+  ]
+}

--- a/traces/phase3_tests_pass19.json
+++ b/traces/phase3_tests_pass19.json
@@ -1,0 +1,8 @@
+{
+  "pass": 19,
+  "timestamp": "2025-07-09T09:39Z",
+  "results": {
+    "crm_node_backend": "passed",
+    "monorepo_tests": "failed - vitest missing"
+  }
+}

--- a/traces/phase3_verification_pass19.json
+++ b/traces/phase3_verification_pass19.json
@@ -1,0 +1,8 @@
+{
+  "pass": 19,
+  "timestamp": "2025-07-09T09:39Z",
+  "assertions": [
+    "node_backend tests run on Node 18",
+    "monorepo tests still fail due to missing vitest"
+  ]
+}


### PR DESCRIPTION
## Summary
- install CRM node_backend deps in install.sh
- record node 18 fix in refactor notes
- log phase 3 pass 19 traces

## Testing
- `npm test` *(fails: vitest missing)*
- `npm test --prefix CRM/node_backend`

------
https://chatgpt.com/codex/tasks/task_e_686e3741fe4483248f4a8ceba6701d43