### PR TITLE
Fix workspace install and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ pnpm install
 npm install --prefix CRM/node_backend
 ```
 
+You can automate these commands using `scripts/install_directus.sh`:
+
+```bash
+./scripts/install_directus.sh
+```
+
 This loads a polyfill for `fs.glob` and installs Jest for the CRM backend before
 executing `pnpm --workspace-root test` and `python3 -m pytest -q`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -241,3 +241,7 @@
 ## Phase 3 – Pass 31 (2025-07-09)
 - Documented Node 18 setup commands in README.
 - Listed CRM Python packages and install command in docs and README.
+
+## Phase 3 – Pass 32 (2025-07-09)
+- Added install_directus.sh script using pnpm.
+- Documented script usage in README.

--- a/scripts/install_directus.sh
+++ b/scripts/install_directus.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_DIR=/var/log/nucleus
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/install_directus.log"
+
+# Activate Node 18 via nvm when available
+if command -v nvm >/dev/null 2>&1; then
+  nvm install 18 >>"$LOG_FILE" 2>&1
+  nvm use 18 >>"$LOG_FILE" 2>&1
+fi
+
+# Allow pnpm to run under Node 18
+export PNPM_IGNORE_NODE_VERSION=true
+export NODE_OPTIONS="--import=$(pwd)/scripts/fs-glob-polyfill.js"
+
+echo "Installing monorepo dependencies via pnpm" | tee "$LOG_FILE"
+pnpm install --silent >>"$LOG_FILE" 2>&1
+
+if [ -d CRM/node_backend ]; then
+  echo "Installing CRM node_backend deps" | tee -a "$LOG_FILE"
+  npm install --prefix CRM/node_backend --silent >>"$LOG_FILE" 2>&1
+fi
+
+echo "Installation complete" | tee -a "$LOG_FILE"

--- a/todo.md
+++ b/todo.md
@@ -36,6 +36,7 @@
 - Install vitest for workspace packages to run monorepo tests {status:todo} {priority:medium} {blocked_by:none}
 - [pass20] Fix maintenance tests path
 - [pass20] Created tests for nucleus-auth and mail-ingest
-- [pass29] Document pnpm installation and test steps in README
+- [pass29] Document pnpm installation and test steps in README {status:done} {priority:low}
 - [pass30] Install Python backend dependencies and run tests {status:done} {priority:low}
 - [pass31] Document Node 18 test setup in README {status:done} {priority:low}
+- [pass32] Add install_directus.sh script using pnpm {status:done} {priority:medium}

--- a/trace.json
+++ b/trace.json
@@ -233,13 +233,49 @@
   {
     "phase": "phase3",
     "pass": 30,
-    "changes": ["traces/phase3_inventory_pass30.json","traces/phase3_fix_pass30.json","traces/phase3_tests_pass30.json","traces/phase3_verification_pass30.json","traces/phase3_integrity_pass30.json","docs/dependencies.md","changelog.md","todo.md"],
+    "changes": [
+      "traces/phase3_inventory_pass30.json",
+      "traces/phase3_fix_pass30.json",
+      "traces/phase3_tests_pass30.json",
+      "traces/phase3_verification_pass30.json",
+      "traces/phase3_integrity_pass30.json",
+      "docs/dependencies.md",
+      "changelog.md",
+      "todo.md"
+    ],
     "trigger": "python deps"
   },
   {
     "phase": "phase3",
     "pass": 31,
-    "changes": ["traces/phase3_inventory_pass31.json","traces/phase3_fix_pass31.json","traces/phase3_tests_pass31.json","traces/phase3_verification_pass31.json","traces/phase3_integrity_pass31.json","README.md","docs/dependencies.md","CRM/README.md","changelog.md","todo.md"],
+    "changes": [
+      "traces/phase3_inventory_pass31.json",
+      "traces/phase3_fix_pass31.json",
+      "traces/phase3_tests_pass31.json",
+      "traces/phase3_verification_pass31.json",
+      "traces/phase3_integrity_pass31.json",
+      "README.md",
+      "docs/dependencies.md",
+      "CRM/README.md",
+      "changelog.md",
+      "todo.md"
+    ],
     "trigger": "node18 docs"
+  },
+  {
+    "phase": "phase3",
+    "pass": 32,
+    "changes": [
+      "traces/phase3_inventory_pass32.json",
+      "traces/phase3_fix_pass32.json",
+      "traces/phase3_tests_pass32.json",
+      "traces/phase3_verification_pass32.json",
+      "traces/phase3_integrity_pass32.json",
+      "scripts/install_directus.sh",
+      "README.md",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "pnpm install script"
   }
 ]

--- a/traces/phase3_fix_pass32.json
+++ b/traces/phase3_fix_pass32.json
@@ -1,0 +1,8 @@
+{
+  "pass": 32,
+  "timestamp": "2025-07-09T19:03Z",
+  "changes": [
+    "Added install_directus.sh script using pnpm",
+    "Documented script usage in README"
+  ]
+}

--- a/traces/phase3_integrity_pass32.json
+++ b/traces/phase3_integrity_pass32.json
@@ -1,0 +1,6 @@
+{
+  "pass": 32,
+  "timestamp": "2025-07-09T19:03Z",
+  "core_modified": false,
+  "notes": "README and scripts only"
+}

--- a/traces/phase3_inventory_pass32.json
+++ b/traces/phase3_inventory_pass32.json
@@ -1,0 +1,9 @@
+{
+  "pass": 32,
+  "timestamp": "2025-07-09T19:03Z",
+  "modules_scanned": [
+    "scripts/install_directus.sh",
+    "README.md"
+  ],
+  "node20_features": []
+}

--- a/traces/phase3_tests_pass32.json
+++ b/traces/phase3_tests_pass32.json
@@ -1,0 +1,9 @@
+{
+  "pass": 32,
+  "timestamp": "2025-07-09T19:03Z",
+  "results": {
+    "npm_test": "failed",
+    "crm_node_backend": "skipped",
+    "crm_python_tests": "skipped"
+  }
+}

--- a/traces/phase3_verification_pass32.json
+++ b/traces/phase3_verification_pass32.json
@@ -1,0 +1,6 @@
+{
+  "pass": 32,
+  "timestamp": "2025-07-09T19:03Z",
+  "core_modified": false,
+  "notes": "Added helper install script"
+}


### PR DESCRIPTION
## Summary
- add `scripts/install_directus.sh` to install dependencies with pnpm
- document use of this script in the README
- record new pass in changelog, todo and trace

## Testing
- `PNPM_IGNORE_NODE_VERSION=true npm test` *(fails: Unsupported engine)*

------
https://chatgpt.com/codex/tasks/task_e_686ebb32b4a883249b6cb393735bab5b