### PR TITLE
pass48: resolve test dependencies

### DIFF
--- a/CRM/scripts/install.sh
+++ b/CRM/scripts/install.sh
@@ -21,8 +21,11 @@ fi
 
 step "Copying extensions"
 mkdir -p "$DIRECTUS_DIR/extensions"
-cp -r "$(dirname "$0")/../extensions/nucleus-auth" "$DIRECTUS_DIR/extensions/" 2>/dev/null || true
-cp -r "$(dirname "$0")/../extensions/nucleus-mail-ingest" "$DIRECTUS_DIR/extensions/" 2>/dev/null || true
+EXT_SRC="$(dirname "$0")/../extensions"
+for ext in "$EXT_SRC"/*; do
+  [ -d "$ext" ] || continue
+  cp -r "$ext" "$DIRECTUS_DIR/extensions/" 2>/dev/null || true
+done
 
 step "Configuring environment"
 if [ ! -f "$DIRECTUS_DIR/.env" ]; then

--- a/changelog.md
+++ b/changelog.md
@@ -311,3 +311,14 @@
 - Added README under /extensions with usage notes.
 - Documented admin features in CRM extension READMEs.
 - Marked documentation TODOs as done.
+
+## Phase 3 – Pass 47 (2025-07-10)
+- Updated CRM/scripts/install.sh to copy all extensions automatically.
+- Marked TODO for extension registration as done.
+- npm and pytest runs fail due to missing Node 22 and sqlalchemy.
+
+## Phase 3 – Pass 48 (2025-07-10)
+- Installed Node 22 using n and updated PATH for tests.
+- Installed Python modules to satisfy pytest: sqlalchemy, fastapi, requests, httpx, pyyaml, pyotp, cryptography, psutil, fpdf2.
+- All 94 Python tests now pass.
+- npm test still fails with vite build exit code 129.

--- a/logs/npm_pass47.log
+++ b/logs/npm_pass47.log
@@ -1,0 +1,13 @@
+
+> pretest
+> pnpm run build
+
+ ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
+
+Your Node version is incompatible with "/workspace/directus".
+
+Expected version: 22
+Got: v20.19.2
+
+This is happening because the package's manifest has an engines.node field specified.
+To fix this issue, install the required Node version.

--- a/logs/npm_pass48.log
+++ b/logs/npm_pass48.log
@@ -1,0 +1,329 @@
+
+> pretest
+> pnpm run build
+
+
+> directus-monorepo@ build /workspace/directus
+> pnpm --recursive --filter '!docs' run build
+
+Scope: 40 of 42 workspace projects
+packages/components build$ vite build
+packages/format-title build$ pnpm run '/^bundle|typecheck$/'
+packages/random build$ tsup src/index.ts --format=esm --dts
+packages/constants build$ tsup src/index.ts --format=esm --dts
+packages/random build: CLI Building entry: src/index.ts
+packages/random build: CLI Using tsconfig: tsconfig.json
+packages/random build: CLI tsup v8.4.0
+packages/constants build: CLI Building entry: src/index.ts
+packages/constants build: CLI Using tsconfig: tsconfig.json
+packages/constants build: CLI tsup v8.4.0
+packages/random build: CLI Target: es2022
+packages/random build: ESM Build start
+packages/constants build: CLI Target: es2022
+packages/constants build: ESM Build start
+packages/random build: ESM dist/index.js 915.00 B
+packages/random build: ESM ⚡️ Build success in 49ms
+packages/constants build: ESM dist/index.js 2.48 KB
+packages/constants build: ESM ⚡️ Build success in 71ms
+packages/format-title build: . bundle$ tsup src/index.ts --format=esm --dts
+packages/format-title build: . typecheck$ tsc --noEmit
+packages/constants build: DTS Build start
+packages/random build: DTS Build start
+packages/format-title build: . bundle: CLI Building entry: src/index.ts
+packages/format-title build: . bundle: CLI Using tsconfig: tsconfig.json
+packages/format-title build: . bundle: CLI tsup v8.4.0
+packages/format-title build: . bundle: CLI Target: es2022
+packages/format-title build: . bundle: ESM Build start
+packages/format-title build: . bundle: ESM dist/index.js 3.78 KB
+packages/format-title build: . bundle: ESM ⚡️ Build success in 94ms
+packages/format-title build: . bundle: DTS Build start
+packages/constants build: DTS ⚡️ Build success in 1315ms
+packages/constants build: DTS dist/index.d.ts 2.44 KB
+packages/constants build: Done
+packages/release-notes-generator build$ tsc --project tsconfig.prod.json
+packages/components build: vite v5.4.19 building for production...
+packages/format-title build: . bundle: DTS ⚡️ Build success in 1091ms
+packages/format-title build: . bundle: DTS dist/index.d.ts 122.00 B
+packages/format-title build: . typecheck: Done
+packages/format-title build: . bundle: Done
+packages/format-title build: Done
+packages/schema build$ tsup src/index.ts --format=esm --dts
+packages/random build: DTS ⚡️ Build success in 2573ms
+packages/random build: DTS dist/index.d.ts 1.13 KB
+packages/random build: Done
+packages/specs build$ swagger-cli bundle src/openapi.yaml -o dist/openapi.json
+packages/schema build: CLI Building entry: src/index.ts
+packages/schema build: CLI Using tsconfig: tsconfig.json
+packages/schema build: CLI tsup v8.4.0
+packages/schema build: CLI Target: es2022
+packages/schema build: ESM Build start
+packages/schema build: ESM dist/index.js 74.29 KB
+packages/schema build: ESM ⚡️ Build success in 152ms
+packages/specs build: Created dist/openapi.json from src/openapi.yaml
+packages/specs build: Done
+packages/storage build$ tsup src/index.ts --format=esm --dts
+packages/release-notes-generator build: Done
+packages/stores build$ tsup src/index.ts --format=esm --dts
+packages/schema build: DTS Build start
+packages/storage build: CLI Building entry: src/index.ts
+packages/storage build: CLI Using tsconfig: tsconfig.json
+packages/storage build: CLI tsup v8.4.0
+packages/storage build: CLI Target: es2022
+packages/storage build: ESM Build start
+packages/storage build: ESM dist/index.js 762.00 B
+packages/storage build: ESM ⚡️ Build success in 84ms
+packages/stores build: CLI Building entry: src/index.ts
+packages/stores build: CLI Using tsconfig: tsconfig.json
+packages/stores build: CLI tsup v8.4.0
+packages/stores build: CLI Target: es2022
+packages/stores build: ESM Build start
+packages/stores build: ESM dist/index.js 857.00 B
+packages/stores build: ESM ⚡️ Build success in 38ms
+packages/storage build: DTS Build start
+packages/components build: transforming...
+packages/components build: ✓ 1 modules transformed.
+packages/components build: Generated an empty chunk: "index".
+packages/components build: rendering chunks...
+packages/stores build: DTS Build start
+packages/components build: [vite:dts] Start generate declaration files...
+packages/components build: computing gzip size...
+packages/components build: dist/index.js  0.00 kB │ gzip: 0.02 kB
+packages/components build: [vite:dts] Declaration files built in 3226ms.
+packages/components build: ✓ built in 3.60s
+packages/components build: Done
+packages/system-data build$ NODE_ENV=production tsup
+packages/system-data build: CLI Building entry: src/index.ts
+packages/system-data build: CLI Using tsconfig: tsconfig.json
+packages/system-data build: CLI tsup v8.4.0
+packages/system-data build: CLI Using tsup config: /workspace/directus/packages/system-data/tsup.config.js
+packages/system-data build: CLI Target: es2020
+packages/system-data build: CLI Cleaning output folder
+packages/system-data build: CJS Build start
+packages/system-data build: ESM Build start
+packages/storage build: DTS ⚡️ Build success in 2543ms
+packages/storage build: DTS dist/index.d.ts 1.87 KB
+packages/storage build: Done
+packages/update-check build$ pnpm run '/^bundle|typecheck$/'
+packages/system-data build: CJS dist/index.cjs 50.64 KB
+packages/system-data build: CJS ⚡️ Build success in 769ms
+packages/system-data build: ESM dist/index.js 50.02 KB
+packages/system-data build: ESM ⚡️ Build success in 777ms
+packages/system-data build: DTS Build start
+packages/schema build: DTS ⚡️ Build success in 4299ms
+packages/schema build: DTS dist/index.d.ts 2.68 KB
+packages/schema build: Done
+packages/update-check build: . bundle$ tsup src/index.ts --format=esm --dts
+packages/update-check build: . typecheck$ tsc --noEmit
+packages/stores build: DTS ⚡️ Build success in 3180ms
+packages/stores build: DTS dist/index.d.ts 1.75 KB
+packages/stores build: Done
+packages/system-data build: DTS ⚡️ Build success in 767ms
+packages/system-data build: DTS dist/index.d.cts 4.92 KB
+packages/system-data build: DTS dist/index.d.ts  4.92 KB
+packages/system-data build: Done
+packages/update-check build: . bundle: CLI Building entry: src/index.ts
+packages/update-check build: . bundle: CLI Using tsconfig: tsconfig.json
+packages/update-check build: . bundle: CLI tsup v8.4.0
+packages/update-check build: . bundle: CLI Target: es2022
+packages/update-check build: . bundle: ESM Build start
+packages/update-check build: . bundle: ESM dist/index.js 3.13 KB
+packages/update-check build: . bundle: ESM ⚡️ Build success in 58ms
+packages/update-check build: . bundle: DTS Build start
+packages/update-check build: . typecheck: Done
+packages/update-check build: . bundle: DTS ⚡️ Build success in 1204ms
+packages/update-check build: . bundle: DTS dist/index.d.ts 94.00 B
+packages/update-check build: . bundle: Done
+packages/update-check build: Done
+packages/errors build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-local build$ tsup src/index.ts --format=esm --dts
+packages/types build$ tsc
+sdk build$ NODE_ENV=production tsup
+packages/errors build: CLI Building entry: src/index.ts
+packages/errors build: CLI Using tsconfig: tsconfig.json
+packages/errors build: CLI tsup v8.4.0
+packages/errors build: CLI Target: es2022
+packages/errors build: ESM Build start
+packages/storage-driver-local build: CLI Building entry: src/index.ts
+packages/storage-driver-local build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-local build: CLI tsup v8.4.0
+packages/storage-driver-local build: CLI Target: es2022
+packages/storage-driver-local build: ESM Build start
+packages/storage-driver-local build: ESM dist/index.js 3.92 KB
+packages/storage-driver-local build: ESM ⚡️ Build success in 37ms
+sdk build: CLI Building entry: src/index.ts
+sdk build: CLI Using tsconfig: tsconfig.json
+sdk build: CLI tsup v8.4.0
+sdk build: CLI Using tsup config: /workspace/directus/sdk/tsup.config.js
+packages/errors build: ESM dist/index.js 10.73 KB
+packages/errors build: ESM ⚡️ Build success in 103ms
+sdk build: CLI Target: es2022
+sdk build: CLI Cleaning output folder
+sdk build: CJS Build start
+sdk build: ESM Build start
+sdk build: ESM dist/index.js     41.57 KB
+sdk build: ESM dist/index.js.map 59.53 KB
+sdk build: ESM ⚡️ Build success in 427ms
+sdk build: CJS dist/index.cjs     45.88 KB
+sdk build: CJS dist/index.cjs.map 66.66 KB
+sdk build: CJS ⚡️ Build success in 427ms
+packages/errors build: DTS Build start
+packages/storage-driver-local build: DTS Build start
+sdk build: DTS Build start
+packages/types build: Done
+packages/errors build: DTS ⚡️ Build success in 1698ms
+packages/errors build: DTS dist/index.d.ts 8.40 KB
+packages/errors build: Done
+packages/storage-driver-local build: DTS ⚡️ Build success in 2055ms
+packages/storage-driver-local build: DTS dist/index.d.ts 1.44 KB
+packages/storage-driver-local build: Done
+sdk build: DTS ⚡️ Build success in 7100ms
+sdk build: DTS dist/index.d.cts 159.14 KB
+sdk build: DTS dist/index.d.ts  159.14 KB
+sdk build: Done
+packages/schema-builder build$ tsup src/index.ts --format=esm --dts
+packages/schema-builder build: CLI Building entry: src/index.ts
+packages/schema-builder build: CLI Using tsconfig: tsconfig.json
+packages/schema-builder build: CLI tsup v8.4.0
+packages/schema-builder build: CLI Target: es2022
+packages/schema-builder build: ESM Build start
+packages/schema-builder build: ESM dist/index.js 20.93 KB
+packages/schema-builder build: ESM ⚡️ Build success in 30ms
+packages/schema-builder build: DTS Build start
+packages/schema-builder build: DTS ⚡️ Build success in 2088ms
+packages/schema-builder build: DTS dist/index.d.ts 4.24 KB
+packages/schema-builder build: Done
+packages/utils build$ pnpm run '/^build:.*/'
+packages/utils build: . build:browser$ tsup browser/index.ts --tsconfig browser/tsconfig.json --out-dir dist/browser --format=esm --dts
+packages/utils build: . build:node$ tsup node/index.ts --tsconfig node/tsconfig.json --out-dir dist/node --format=esm --dts
+packages/utils build: . build:shared$ tsup shared/index.ts --tsconfig shared/tsconfig.json --out-dir dist/shared --format=esm --dts
+packages/utils build: . build:browser: CLI Building entry: browser/index.ts
+packages/utils build: . build:node: CLI Building entry: node/index.ts
+packages/utils build: . build:node: CLI Using tsconfig: node/tsconfig.json
+packages/utils build: . build:node: CLI tsup v8.4.0
+packages/utils build: . build:browser: CLI Using tsconfig: browser/tsconfig.json
+packages/utils build: . build:browser: CLI tsup v8.4.0
+packages/utils build: . build:shared: CLI Building entry: shared/index.ts
+packages/utils build: . build:shared: CLI Using tsconfig: shared/tsconfig.json
+packages/utils build: . build:shared: CLI tsup v8.4.0
+packages/utils build: . build:node: CLI Target: es2022
+packages/utils build: . build:node: ESM Build start
+packages/utils build: . build:browser: CLI Target: es2022
+packages/utils build: . build:shared: CLI Target: es2022
+packages/utils build: . build:shared: ESM Build start
+packages/utils build: . build:browser: ESM Build start
+packages/utils build: . build:browser: ESM dist/browser/index.js 177.00 B
+packages/utils build: . build:browser: ESM ⚡️ Build success in 71ms
+packages/utils build: . build:node: ESM dist/node/index.js 3.56 KB
+packages/utils build: . build:node: ESM ⚡️ Build success in 86ms
+packages/utils build: . build:shared: ESM dist/shared/index.js 40.89 KB
+packages/utils build: . build:shared: ESM ⚡️ Build success in 126ms
+packages/utils build: . build:shared: DTS Build start
+packages/utils build: . build:node: DTS Build start
+packages/utils build: . build:browser: DTS Build start
+packages/utils build: . build:browser: DTS ⚡️ Build success in 1138ms
+packages/utils build: . build:browser: DTS dist/browser/index.d.ts 149.00 B
+packages/utils build: . build:browser: Done
+packages/utils build: . build:node: DTS ⚡️ Build success in 2209ms
+packages/utils build: . build:node: DTS dist/node/index.d.ts 1.66 KB
+packages/utils build: . build:node: Done
+packages/utils build: . build:shared: DTS ⚡️ Build success in 3107ms
+packages/utils build: . build:shared: DTS dist/shared/index.d.ts 8.67 KB
+packages/utils build: . build:shared: Done
+packages/utils build: Done
+packages/memory build$ tsup src/index.ts --format=esm --dts
+packages/pressure build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-azure build$ tsup src/index.ts --format=esm --dts
+packages/env build$ tsup src/index.ts --format=esm --dts
+packages/pressure build: CLI Building entry: src/index.ts
+packages/pressure build: CLI Using tsconfig: tsconfig.json
+packages/pressure build: CLI tsup v8.4.0
+packages/storage-driver-azure build: CLI Building entry: src/index.ts
+packages/storage-driver-azure build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-azure build: CLI tsup v8.4.0
+packages/storage-driver-azure build: CLI Target: es2022
+packages/storage-driver-azure build: ESM Build start
+packages/pressure build: CLI Target: es2022
+packages/pressure build: ESM Build start
+packages/env build: CLI Building entry: src/index.ts
+packages/env build: CLI Using tsconfig: tsconfig.json
+packages/env build: CLI tsup v8.4.0
+packages/memory build: CLI Building entry: src/index.ts
+packages/memory build: CLI Using tsconfig: tsconfig.json
+packages/memory build: CLI tsup v8.4.0
+packages/env build: CLI Target: es2022
+packages/env build: ESM Build start
+packages/memory build: CLI Target: es2022
+packages/memory build: ESM Build start
+packages/storage-driver-azure build: ESM dist/index.js 3.74 KB
+packages/storage-driver-azure build: ESM ⚡️ Build success in 56ms
+packages/pressure build: ESM dist/index.js 2.25 KB
+packages/pressure build: ESM ⚡️ Build success in 65ms
+packages/env build: ESM dist/index.js 17.72 KB
+packages/env build: ESM ⚡️ Build success in 71ms
+packages/memory build: ESM dist/index.js 13.57 KB
+packages/memory build: ESM ⚡️ Build success in 111ms
+packages/storage-driver-azure build: DTS Build start
+packages/memory build: DTS Build start
+packages/env build: DTS Build start
+packages/pressure build: DTS Build start
+packages/pressure build: DTS ⚡️ Build success in 3470ms
+packages/pressure build: DTS dist/index.d.ts 885.00 B
+packages/pressure build: Done
+packages/storage-driver-cloudinary build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-azure build: DTS ⚡️ Build success in 3666ms
+packages/storage-driver-azure build: DTS dist/index.d.ts 1.52 KB
+packages/storage-driver-azure build: Done
+packages/storage-driver-gcs build$ tsup src/index.ts --format=esm --dts
+packages/env build: DTS ⚡️ Build success in 3830ms
+packages/env build: DTS dist/index.d.ts 90.00 B
+packages/env build: Done
+packages/storage-driver-s3 build$ tsup src/index.ts --format=esm --dts
+packages/memory build: DTS ⚡️ Build success in 4040ms
+packages/memory build: DTS dist/index.d.ts 13.45 KB
+packages/memory build: Done
+packages/storage-driver-supabase build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-cloudinary build: CLI Building entry: src/index.ts
+packages/storage-driver-cloudinary build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-cloudinary build: CLI tsup v8.4.0
+packages/storage-driver-cloudinary build: CLI Target: es2022
+packages/storage-driver-cloudinary build: ESM Build start
+packages/storage-driver-gcs build: CLI Building entry: src/index.ts
+packages/storage-driver-gcs build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-gcs build: CLI tsup v8.4.0
+packages/storage-driver-gcs build: CLI Target: es2022
+packages/storage-driver-gcs build: ESM Build start
+packages/storage-driver-cloudinary build: ESM dist/index.js 13.81 KB
+packages/storage-driver-cloudinary build: ESM ⚡️ Build success in 55ms
+packages/storage-driver-gcs build: ESM dist/index.js 3.54 KB
+packages/storage-driver-gcs build: ESM ⚡️ Build success in 28ms
+packages/storage-driver-s3 build: CLI Building entry: src/index.ts
+packages/storage-driver-s3 build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-s3 build: CLI tsup v8.4.0
+packages/storage-driver-s3 build: CLI Target: es2022
+packages/storage-driver-s3 build: ESM Build start
+packages/storage-driver-s3 build: ESM dist/index.js 12.19 KB
+packages/storage-driver-s3 build: ESM ⚡️ Build success in 45ms
+packages/storage-driver-supabase build: CLI Building entry: src/index.ts
+packages/storage-driver-supabase build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-supabase build: CLI tsup v8.4.0
+packages/storage-driver-supabase build: CLI Target: es2022
+packages/storage-driver-supabase build: ESM Build start
+packages/storage-driver-supabase build: ESM dist/index.js 6.46 KB
+packages/storage-driver-supabase build: ESM ⚡️ Build success in 42ms
+packages/storage-driver-cloudinary build: DTS Build start
+packages/storage-driver-gcs build: DTS Build start
+packages/storage-driver-s3 build: DTS Build start
+packages/storage-driver-supabase build: DTS Build start
+packages/storage-driver-cloudinary build: DTS ⚡️ Build success in 3667ms
+packages/storage-driver-cloudinary build: DTS dist/index.d.ts 2.85 KB
+packages/storage-driver-cloudinary build: Done
+packages/themes build$ vite build
+packages/themes build: Failed
+/workspace/directus/packages/themes:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @directus/themes@1.1.2 build: `vite build`
+Exit status 129
+packages/validation build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-supabase build: Failed
+packages/storage-driver-gcs build: Failed
+packages/storage-driver-s3 build: Failed
+ ELIFECYCLE  Command failed with exit code 129.

--- a/logs/pytest_pass47.log
+++ b/logs/pytest_pass47.log
@@ -1,0 +1,29 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
+rootdir: /workspace/directus
+collected 0 items / 1 error
+
+==================================== ERRORS ====================================
+__________________________ ERROR collecting CRM/tests __________________________
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+CRM/tests/conftest.py:4: in <module>
+    from backend.database import Base, engine
+CRM/backend/database.py:5: in <module>
+    from sqlalchemy import create_engine
+E   ModuleNotFoundError: No module named 'sqlalchemy'
+=========================== short test summary info ============================
+ERROR CRM/tests - ModuleNotFoundError: No module named 'sqlalchemy'
+!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
+=============================== 1 error in 0.87s ===============================

--- a/logs/pytest_pass48.log
+++ b/logs/pytest_pass48.log
@@ -1,0 +1,52 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
+rootdir: /workspace/directus
+plugins: anyio-4.9.0
+collected 94 items
+
+CRM/tests/test_acme.py .                                                 [  1%]
+CRM/tests/test_assets.py ....                                            [  5%]
+CRM/tests/test_auth.py ...                                               [  8%]
+CRM/tests/test_backup.py ...                                             [ 11%]
+CRM/tests/test_cases.py .                                                [ 12%]
+CRM/tests/test_cli.py ........                                           [ 21%]
+CRM/tests/test_cms.py ..                                                 [ 23%]
+CRM/tests/test_config_api.py ..                                          [ 25%]
+CRM/tests/test_contracts.py .                                            [ 26%]
+CRM/tests/test_core.py ....                                              [ 30%]
+CRM/tests/test_cors.py .                                                 [ 31%]
+CRM/tests/test_crm.py ..                                                 [ 34%]
+CRM/tests/test_crm_dmarc.py .....                                        [ 39%]
+CRM/tests/test_crm_domains.py .                                          [ 40%]
+CRM/tests/test_crm_sync.py .                                             [ 41%]
+CRM/tests/test_distributors.py .                                         [ 42%]
+CRM/tests/test_dmarc.py ..                                               [ 44%]
+CRM/tests/test_docs.py ...                                               [ 47%]
+CRM/tests/test_edi.py .                                                  [ 48%]
+CRM/tests/test_keycloak.py ...                                           [ 52%]
+CRM/tests/test_lint.py .                                                 [ 53%]
+CRM/tests/test_login_page.py .............                               [ 67%]
+CRM/tests/test_mail.py .                                                 [ 68%]
+CRM/tests/test_maintenance.py ...                                        [ 71%]
+CRM/tests/test_partners.py .                                             [ 72%]
+CRM/tests/test_portal.py .                                               [ 73%]
+CRM/tests/test_public.py .                                               [ 74%]
+CRM/tests/test_root.py .                                                 [ 75%]
+CRM/tests/test_security.py .                                             [ 76%]
+CRM/tests/test_security_scan.py ...                                      [ 79%]
+CRM/tests/test_sophos.py ..                                              [ 81%]
+CRM/tests/test_status.py .                                               [ 82%]
+CRM/tests/test_support.py .                                              [ 84%]
+CRM/tests/test_system_check.py .                                         [ 85%]
+CRM/tests/test_tenable.py ..                                             [ 87%]
+CRM/tests/test_tickets.py ..                                             [ 89%]
+CRM/tests/test_update.py ...                                             [ 92%]
+CRM/tests/test_yubikey.py .......                                        [100%]
+
+=============================== warnings summary ===============================
+CRM/tests/test_login_page.py::test_cookie_authentication
+  /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/starlette/testclient.py:437: DeprecationWarning: Setting per-request cookies=<...> is being deprecated, because the expected behaviour on cookie persistence is ambiguous. Set cookies directly on the client instance instead.
+    return super().request(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 94 passed, 1 warning in 55.61s ========================

--- a/loops/register-extensions_pass47.md
+++ b/loops/register-extensions_pass47.md
@@ -1,0 +1,2 @@
+Updated install.sh to copy all CRM extensions dynamically.
+Marked TODO as done and logged failing tests.

--- a/loops/resolve-tests_pass48.md
+++ b/loops/resolve-tests_pass48.md
@@ -1,0 +1,1 @@
+Installed Node 22 and Python dependencies (sqlalchemy, fastapi, requests, httpx, pyyaml, pyotp, cryptography, psutil, fpdf2). Python tests now pass (94 tests). npm test still fails during the vite build with exit code 129.

--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@
 - Create authentication schema {status:in-progress} {priority:high} {blocked_by:none}
 
 ## nucleus-core
-- Register each CRM extension in install.sh {status:in-progress} {priority:medium} {blocked_by:none}
+- Register each CRM extension in install.sh {status:done} {priority:medium} {blocked_by:none}
  - Automate building workspace packages before tests {status:done} {priority:medium} {blocked_by:none}
 
 ## nucleus-api
@@ -40,7 +40,7 @@
 - [pass30] Install Python backend dependencies and run tests {status:done} {priority:low}
 - [pass31] Document Node 18 test setup in README {status:done} {priority:low}
 - [pass32] Add install_directus.sh script using pnpm {status:done} {priority:medium}
-- [pass33] Build and test pipeline failing due to missing vitest modules and sqlalchemy
+- [pass33] Build and test pipeline failing due to missing vitest modules and sqlalchemy {status:done}
 - [pass34] Update docs to emphasize Node 22 as default runtime {status:done} {priority:low}
 - [pass36] Update install scripts to use Node 22 {status:done} {priority:low}
  - Resolve npm install workspace protocol issues {status:done} {priority:high} {blocked_by:none}

--- a/trace.json
+++ b/trace.json
@@ -463,5 +463,30 @@
       "changelog.md"
     ],
     "trigger": "document extensions"
+  },
+  {
+    "phase": "phase3",
+    "pass": 47,
+    "changes": [
+      "loops/register-extensions_pass47.md",
+      "CRM/scripts/install.sh",
+      "todo.md",
+      "changelog.md",
+      "logs/npm_pass47.log",
+      "logs/pytest_pass47.log"
+    ],
+    "trigger": "register extensions dynamically"
+  },
+  {
+    "phase": "phase3",
+    "pass": 48,
+    "changes": [
+      "loops/resolve-tests_pass48.md",
+      "logs/npm_pass48.log",
+      "logs/pytest_pass48.log",
+      "todo.md",
+      "changelog.md"
+    ],
+    "trigger": "resolve failing tests"
   }
 ]


### PR DESCRIPTION
## Summary
- install Node 22 with `n` for running tests
- install Python dependencies to satisfy pytest
- log npm failure and successful pytest run
- mark pipeline TODO complete

## Testing
- `npm test` *(fails: vite build exit code 129)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f5f4bdcfc8324b825de0f26716203