### PR TITLE
pass49: document test_install usage

### DIFF
--- a/CRM/docs/loops/lynx_test.md
+++ b/CRM/docs/loops/lynx_test.md
@@ -1,6 +1,6 @@
 # Lynx test procedure
 
-Run `./test_install.sh` to start the backend and auth services locally. This script installs Python and Node dependencies, launches the servers on localhost, and waits for ports 8000 and 3001 to respond.
+From the repository root run `CRM/test_install.sh` to start the backend and auth services locally. This script installs Python and Node dependencies, launches the servers on localhost, and waits for ports 8000 and 3001 to respond.
 Do not run `install.sh` or `scripts/patch_services.sh` in the Codex environment; they are production only.
 Ensure `fpdf2` and `psutil` are installed in the Python environment before running tests.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ before executing `pnpm --workspace-root test` and `python3 -m pytest -q`.
 
 ## Testing the GUI
 
-Run `scripts/gui_loop.sh` to install dependencies, launch the services and
-execute the headless browser checks via `scripts/headless_check.js`. Results are
-stored in the `logs/` directory.
+Run `CRM/test_install.sh` first to start the backend and auth services locally.
+After the services are active, execute `scripts/gui_loop.sh` to install
+dependencies and run the headless browser checks via `scripts/headless_check.js`.
+Results are stored in the `logs/` directory.
 

--- a/agents.md
+++ b/agents.md
@@ -15,4 +15,5 @@ Governance rules forbid touching upstream Directus code outside the `CRM/` and `
 Current prompt roles: **system**, **developer**, **user**.
 
 For detailed CLI↔GUI mapping see `CRM/AGENTS.md`.
+Run `CRM/test_install.sh` before executing any browser-based or headless GUI tests so the backend and auth services are running locally.
 

--- a/changelog.md
+++ b/changelog.md
@@ -322,3 +322,8 @@
 - Installed Python modules to satisfy pytest: sqlalchemy, fastapi, requests, httpx, pyyaml, pyotp, cryptography, psutil, fpdf2.
 - All 94 Python tests now pass.
 - npm test still fails with vite build exit code 129.
+
+## Phase 3 – Pass 49 (2025-07-10)
+- Documented test_install.sh usage in agents.md and README.
+- Installed Node 22 with pnpm, ran npm test (fails due to missing packages).
+- Installed Python dependencies and ran pytest successfully (94 tests).

--- a/logs/npm_pass49.log
+++ b/logs/npm_pass49.log
@@ -1,0 +1,34 @@
+
+> pretest
+> pnpm run build
+
+
+> directus-monorepo@ build /workspace/directus
+> pnpm --recursive --filter '!docs' run build
+
+Scope: 40 of 42 workspace projects
+packages/components build$ vite build
+packages/constants build$ tsup src/index.ts --format=esm --dts
+packages/format-title build$ pnpm run '/^bundle|typecheck$/'
+packages/random build$ tsup src/index.ts --format=esm --dts
+packages/components build: command not found: vite
+packages/components build: Failed
+/workspace/directus/packages/components:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @directus/components@1.1.1 build: `vite build`
+Exit status 127
+packages/constants build: command not found: tsup
+packages/constants build: Failed
+packages/random build: command not found: tsup
+packages/random build: Failed
+ WARN   Local package.json exists, but node_modules missing, did you mean to install?
+packages/release-notes-generator build$ tsc --project tsconfig.prod.json
+ WARN   Local package.json exists, but node_modules missing, did you mean to install?
+packages/schema build$ tsup src/index.ts --format=esm --dts
+ WARN   Local package.json exists, but node_modules missing, did you mean to install?
+packages/specs build$ swagger-cli bundle src/openapi.yaml -o dist/openapi.json
+packages/schema build: command not found: tsup
+packages/schema build: Failed
+packages/specs build: command not found: swagger-cli
+packages/specs build: Failed
+ ELIFECYCLE  Command failed with exit code 127.
+ WARN   Local package.json exists, but node_modules missing, did you mean to install?

--- a/logs/pytest_pass49.log
+++ b/logs/pytest_pass49.log
@@ -1,0 +1,9 @@
+........................................................................ [ 76%]
+......................                                                   [100%]
+=============================== warnings summary ===============================
+CRM/tests/test_login_page.py::test_cookie_authentication
+  /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/starlette/testclient.py:437: DeprecationWarning: Setting per-request cookies=<...> is being deprecated, because the expected behaviour on cookie persistence is ambiguous. Set cookies directly on the client instance instead.
+    return super().request(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+94 passed, 1 warning in 31.25s

--- a/loops/open-closed-loop_pass49.md
+++ b/loops/open-closed-loop_pass49.md
@@ -1,0 +1,5 @@
+# open-closed-loop_pass49
+Updated agents.md and README to instruct running CRM/test_install.sh before any GUI tests.
+Installed Node 22 via nvm and pnpm globally, then executed npm test which failed during package build.
+Installed required Python modules and ran pytest (94 tests passed).
+Logs saved as logs/npm_pass49.log and logs/pytest_pass49.log.

--- a/todo.md
+++ b/todo.md
@@ -46,3 +46,4 @@
  - Resolve npm install workspace protocol issues {status:done} {priority:high} {blocked_by:none}
 - [pass37] Added build and boot memory DB tests {status:done} {priority:low}
 - [pass38] Fix memory DB test path and node usage {status:done} {priority:low}
+- Document running CRM/test_install.sh before GUI testing {status:done} {priority:low} {blocked_by:none}

--- a/trace.json
+++ b/trace.json
@@ -488,5 +488,17 @@
       "changelog.md"
     ],
     "trigger": "resolve failing tests"
+  },
+  {
+    "phase": "phase3",
+    "pass": 49,
+    "changes": [
+      "loops/open-closed-loop_pass49.md",
+      "logs/npm_pass49.log",
+      "logs/pytest_pass49.log",
+      "todo.md",
+      "changelog.md"
+    ],
+    "trigger": "open closed loop"
   }
 ]


### PR DESCRIPTION
## Summary
- update root AGENTS with test_install.sh notice
- document test_install usage in README
- clarify path in lynx test docs
- record logs and update traces

## Testing
- `npm test` *(fails: command not found: tsup)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9f1829d48324950dcf464dc7b3ce