### PR TITLE
Add scaffolds for missing Directus modules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -355,3 +355,8 @@
 - Added Keycloak auth extension and test.
 - Documented extension in `extensions/README.md`.
 - npm test still fails in @directus/api; pytest missing sqlalchemy.
+
+## Phase 3 – Pass 56 (2025-07-14)
+- Scaffolded missing Directus extensions under `extensions/`.
+- Ran `npx directus extension install` for each; command not recognized.
+- Executed `pnpm install` and `npm test` (tests still failing in @directus/themes).

--- a/extensions/nucleus-api/index.js
+++ b/extensions/nucleus-api/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-api/package.json
+++ b/extensions/nucleus-api/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-api",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-contracts/index.js
+++ b/extensions/nucleus-contracts/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-contracts/package.json
+++ b/extensions/nucleus-contracts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-contracts",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-crm/index.js
+++ b/extensions/nucleus-crm/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-crm/package.json
+++ b/extensions/nucleus-crm/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-crm",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-dmarc/index.js
+++ b/extensions/nucleus-dmarc/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-dmarc/package.json
+++ b/extensions/nucleus-dmarc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-dmarc",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-docs/index.js
+++ b/extensions/nucleus-docs/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-docs/package.json
+++ b/extensions/nucleus-docs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-docs",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-edi/index.js
+++ b/extensions/nucleus-edi/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-edi/package.json
+++ b/extensions/nucleus-edi/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-edi",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-portal/index.js
+++ b/extensions/nucleus-portal/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-portal/package.json
+++ b/extensions/nucleus-portal/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-portal",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-sophos/index.js
+++ b/extensions/nucleus-sophos/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-sophos/package.json
+++ b/extensions/nucleus-sophos/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-sophos",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-support/index.js
+++ b/extensions/nucleus-support/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-support/package.json
+++ b/extensions/nucleus-support/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-support",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-tenable/index.js
+++ b/extensions/nucleus-tenable/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-tenable/package.json
+++ b/extensions/nucleus-tenable/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-tenable",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/extensions/nucleus-ui/index.js
+++ b/extensions/nucleus-ui/index.js
@@ -1,0 +1,1 @@
+export default function register() {}

--- a/extensions/nucleus-ui/package.json
+++ b/extensions/nucleus-ui/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-ui",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/logs/install_nucleus-api.log
+++ b/logs/install_nucleus-api.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-contracts.log
+++ b/logs/install_nucleus-contracts.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-crm.log
+++ b/logs/install_nucleus-crm.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-dmarc.log
+++ b/logs/install_nucleus-dmarc.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-docs.log
+++ b/logs/install_nucleus-docs.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-edi.log
+++ b/logs/install_nucleus-edi.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-portal.log
+++ b/logs/install_nucleus-portal.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-sophos.log
+++ b/logs/install_nucleus-sophos.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-support.log
+++ b/logs/install_nucleus-support.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-tenable.log
+++ b/logs/install_nucleus-tenable.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/install_nucleus-ui.log
+++ b/logs/install_nucleus-ui.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm.
+error: unknown command 'extension'

--- a/logs/npm_pass56.log
+++ b/logs/npm_pass56.log
@@ -1,0 +1,348 @@
+
+> pretest
+> pnpm run build
+
+
+> directus-monorepo@ build /workspace/directus
+> pnpm --recursive --filter '!docs' run build
+
+Scope: 41 of 43 workspace projects
+packages/components build$ vite build
+packages/constants build$ tsup src/index.ts --format=esm --dts
+packages/random build$ tsup src/index.ts --format=esm --dts
+packages/format-title build$ pnpm run '/^bundle|typecheck$/'
+packages/random build: CLI Building entry: src/index.ts
+packages/random build: CLI Using tsconfig: tsconfig.json
+packages/random build: CLI tsup v8.4.0
+packages/constants build: CLI Building entry: src/index.ts
+packages/constants build: CLI Using tsconfig: tsconfig.json
+packages/constants build: CLI tsup v8.4.0
+packages/random build: CLI Target: es2022
+packages/random build: ESM Build start
+packages/constants build: CLI Target: es2022
+packages/constants build: ESM Build start
+packages/random build: ESM dist/index.js 915.00 B
+packages/random build: ESM ⚡️ Build success in 33ms
+packages/format-title build: . bundle$ tsup src/index.ts --format=esm --dts
+packages/format-title build: . typecheck$ tsc --noEmit
+packages/constants build: ESM dist/index.js 2.48 KB
+packages/constants build: ESM ⚡️ Build success in 58ms
+packages/random build: DTS Build start
+packages/constants build: DTS Build start
+packages/format-title build: . bundle: CLI Building entry: src/index.ts
+packages/format-title build: . bundle: CLI Using tsconfig: tsconfig.json
+packages/format-title build: . bundle: CLI tsup v8.4.0
+packages/format-title build: . bundle: CLI Target: es2022
+packages/format-title build: . bundle: ESM Build start
+packages/format-title build: . bundle: ESM dist/index.js 3.78 KB
+packages/format-title build: . bundle: ESM ⚡️ Build success in 143ms
+packages/format-title build: . bundle: DTS Build start
+packages/constants build: DTS ⚡️ Build success in 1409ms
+packages/constants build: DTS dist/index.d.ts 2.44 KB
+packages/constants build: Done
+packages/release-notes-generator build$ tsc --project tsconfig.prod.json
+packages/components build: vite v5.4.19 building for production...
+packages/format-title build: . bundle: DTS ⚡️ Build success in 1199ms
+packages/format-title build: . bundle: DTS dist/index.d.ts 122.00 B
+packages/format-title build: . bundle: Done
+packages/format-title build: . typecheck: Done
+packages/format-title build: Done
+packages/schema build$ tsup src/index.ts --format=esm --dts
+packages/random build: DTS ⚡️ Build success in 3066ms
+packages/random build: DTS dist/index.d.ts 1.13 KB
+packages/random build: Done
+packages/specs build$ swagger-cli bundle src/openapi.yaml -o dist/openapi.json
+packages/schema build: CLI Building entry: src/index.ts
+packages/schema build: CLI Using tsconfig: tsconfig.json
+packages/schema build: CLI tsup v8.4.0
+packages/schema build: CLI Target: es2022
+packages/schema build: ESM Build start
+packages/schema build: ESM dist/index.js 74.29 KB
+packages/schema build: ESM ⚡️ Build success in 130ms
+packages/specs build: Created dist/openapi.json from src/openapi.yaml
+packages/specs build: Done
+packages/storage build$ tsup src/index.ts --format=esm --dts
+packages/schema build: DTS Build start
+packages/release-notes-generator build: Done
+packages/stores build$ tsup src/index.ts --format=esm --dts
+packages/storage build: CLI Building entry: src/index.ts
+packages/storage build: CLI Using tsconfig: tsconfig.json
+packages/storage build: CLI tsup v8.4.0
+packages/storage build: CLI Target: es2022
+packages/storage build: ESM Build start
+packages/storage build: ESM dist/index.js 762.00 B
+packages/storage build: ESM ⚡️ Build success in 36ms
+packages/stores build: CLI Building entry: src/index.ts
+packages/stores build: CLI Using tsconfig: tsconfig.json
+packages/stores build: CLI tsup v8.4.0
+packages/stores build: CLI Target: es2022
+packages/stores build: ESM Build start
+packages/stores build: ESM dist/index.js 857.00 B
+packages/stores build: ESM ⚡️ Build success in 55ms
+packages/storage build: DTS Build start
+packages/stores build: DTS Build start
+packages/components build: transforming...
+packages/components build: ✓ 1 modules transformed.
+packages/components build: Generated an empty chunk: "index".
+packages/components build: rendering chunks...
+packages/components build: [vite:dts] Start generate declaration files...
+packages/components build: computing gzip size...
+packages/components build: dist/index.js  0.00 kB │ gzip: 0.02 kB
+packages/components build: [vite:dts] Declaration files built in 4011ms.
+packages/components build: ✓ built in 4.57s
+packages/components build: Done
+packages/system-data build$ NODE_ENV=production tsup
+packages/storage build: DTS ⚡️ Build success in 2572ms
+packages/storage build: DTS dist/index.d.ts 1.87 KB
+packages/storage build: Done
+packages/update-check build$ pnpm run '/^bundle|typecheck$/'
+packages/schema build: DTS ⚡️ Build success in 4033ms
+packages/schema build: DTS dist/index.d.ts 2.68 KB
+packages/schema build: Done
+packages/system-data build: CLI Building entry: src/index.ts
+packages/system-data build: CLI Using tsconfig: tsconfig.json
+packages/system-data build: CLI tsup v8.4.0
+packages/system-data build: CLI Using tsup config: /workspace/directus/packages/system-data/tsup.config.js
+packages/system-data build: CLI Target: es2020
+packages/system-data build: CLI Cleaning output folder
+packages/system-data build: CJS Build start
+packages/system-data build: ESM Build start
+packages/update-check build: . bundle$ tsup src/index.ts --format=esm --dts
+packages/update-check build: . typecheck$ tsc --noEmit
+packages/system-data build: ESM dist/index.js 50.02 KB
+packages/system-data build: ESM ⚡️ Build success in 571ms
+packages/system-data build: CJS dist/index.cjs 50.64 KB
+packages/system-data build: CJS ⚡️ Build success in 572ms
+packages/system-data build: DTS Build start
+packages/stores build: DTS ⚡️ Build success in 3218ms
+packages/stores build: DTS dist/index.d.ts 1.75 KB
+packages/stores build: Done
+packages/update-check build: . bundle: CLI Building entry: src/index.ts
+packages/update-check build: . bundle: CLI Using tsconfig: tsconfig.json
+packages/update-check build: . bundle: CLI tsup v8.4.0
+packages/update-check build: . bundle: CLI Target: es2022
+packages/update-check build: . bundle: ESM Build start
+packages/update-check build: . bundle: ESM dist/index.js 3.13 KB
+packages/update-check build: . bundle: ESM ⚡️ Build success in 49ms
+packages/update-check build: . bundle: DTS Build start
+packages/system-data build: DTS ⚡️ Build success in 798ms
+packages/system-data build: DTS dist/index.d.cts 4.92 KB
+packages/system-data build: DTS dist/index.d.ts  4.92 KB
+packages/system-data build: Done
+packages/update-check build: . typecheck: Done
+packages/update-check build: . bundle: DTS ⚡️ Build success in 1400ms
+packages/update-check build: . bundle: DTS dist/index.d.ts 94.00 B
+packages/update-check build: . bundle: Done
+packages/update-check build: Done
+packages/storage-driver-local build$ tsup src/index.ts --format=esm --dts
+packages/errors build$ tsup src/index.ts --format=esm --dts
+packages/types build$ tsc
+sdk build$ NODE_ENV=production tsup
+packages/storage-driver-local build: CLI Building entry: src/index.ts
+packages/storage-driver-local build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-local build: CLI tsup v8.4.0
+packages/storage-driver-local build: CLI Target: es2022
+packages/storage-driver-local build: ESM Build start
+packages/errors build: CLI Building entry: src/index.ts
+packages/errors build: CLI Using tsconfig: tsconfig.json
+packages/errors build: CLI tsup v8.4.0
+packages/storage-driver-local build: ESM dist/index.js 3.92 KB
+packages/storage-driver-local build: ESM ⚡️ Build success in 39ms
+packages/errors build: CLI Target: es2022
+packages/errors build: ESM Build start
+sdk build: CLI Building entry: src/index.ts
+sdk build: CLI Using tsconfig: tsconfig.json
+sdk build: CLI tsup v8.4.0
+sdk build: CLI Using tsup config: /workspace/directus/sdk/tsup.config.js
+sdk build: CLI Target: es2022
+sdk build: CLI Cleaning output folder
+sdk build: CJS Build start
+sdk build: ESM Build start
+packages/errors build: ESM dist/index.js 10.73 KB
+packages/errors build: ESM ⚡️ Build success in 85ms
+packages/errors build: DTS Build start
+packages/storage-driver-local build: DTS Build start
+sdk build: CJS dist/index.cjs     45.88 KB
+sdk build: CJS dist/index.cjs.map 66.66 KB
+sdk build: CJS ⚡️ Build success in 942ms
+sdk build: ESM dist/index.js     41.57 KB
+sdk build: ESM dist/index.js.map 59.53 KB
+sdk build: ESM ⚡️ Build success in 942ms
+sdk build: DTS Build start
+packages/types build: Done
+packages/errors build: DTS ⚡️ Build success in 1765ms
+packages/errors build: DTS dist/index.d.ts 8.40 KB
+packages/errors build: Done
+packages/storage-driver-local build: DTS ⚡️ Build success in 2388ms
+packages/storage-driver-local build: DTS dist/index.d.ts 1.44 KB
+packages/storage-driver-local build: Done
+sdk build: DTS ⚡️ Build success in 6716ms
+sdk build: DTS dist/index.d.cts 159.14 KB
+sdk build: DTS dist/index.d.ts  159.14 KB
+sdk build: Done
+packages/schema-builder build$ tsup src/index.ts --format=esm --dts
+packages/schema-builder build: CLI Building entry: src/index.ts
+packages/schema-builder build: CLI Using tsconfig: tsconfig.json
+packages/schema-builder build: CLI tsup v8.4.0
+packages/schema-builder build: CLI Target: es2022
+packages/schema-builder build: ESM Build start
+packages/schema-builder build: ESM dist/index.js 20.93 KB
+packages/schema-builder build: ESM ⚡️ Build success in 78ms
+packages/schema-builder build: DTS Build start
+packages/schema-builder build: DTS ⚡️ Build success in 2244ms
+packages/schema-builder build: DTS dist/index.d.ts 4.24 KB
+packages/schema-builder build: Done
+packages/utils build$ pnpm run '/^build:.*/'
+packages/utils build: . build:browser$ tsup browser/index.ts --tsconfig browser/tsconfig.json --out-dir dist/browser --format=esm --dts
+packages/utils build: . build:node$ tsup node/index.ts --tsconfig node/tsconfig.json --out-dir dist/node --format=esm --dts
+packages/utils build: . build:shared$ tsup shared/index.ts --tsconfig shared/tsconfig.json --out-dir dist/shared --format=esm --dts
+packages/utils build: . build:node: CLI Building entry: node/index.ts
+packages/utils build: . build:node: CLI Using tsconfig: node/tsconfig.json
+packages/utils build: . build:node: CLI tsup v8.4.0
+packages/utils build: . build:browser: CLI Building entry: browser/index.ts
+packages/utils build: . build:browser: CLI Using tsconfig: browser/tsconfig.json
+packages/utils build: . build:browser: CLI tsup v8.4.0
+packages/utils build: . build:shared: CLI Building entry: shared/index.ts
+packages/utils build: . build:shared: CLI Using tsconfig: shared/tsconfig.json
+packages/utils build: . build:shared: CLI tsup v8.4.0
+packages/utils build: . build:node: CLI Target: es2022
+packages/utils build: . build:node: ESM Build start
+packages/utils build: . build:browser: CLI Target: es2022
+packages/utils build: . build:browser: ESM Build start
+packages/utils build: . build:shared: CLI Target: es2022
+packages/utils build: . build:shared: ESM Build start
+packages/utils build: . build:browser: ESM dist/browser/index.js 177.00 B
+packages/utils build: . build:browser: ESM ⚡️ Build success in 28ms
+packages/utils build: . build:node: ESM dist/node/index.js 3.56 KB
+packages/utils build: . build:node: ESM ⚡️ Build success in 37ms
+packages/utils build: . build:shared: ESM dist/shared/index.js 40.89 KB
+packages/utils build: . build:shared: ESM ⚡️ Build success in 87ms
+packages/utils build: . build:shared: DTS Build start
+packages/utils build: . build:browser: DTS Build start
+packages/utils build: . build:node: DTS Build start
+packages/utils build: . build:browser: DTS ⚡️ Build success in 1514ms
+packages/utils build: . build:browser: DTS dist/browser/index.d.ts 149.00 B
+packages/utils build: . build:browser: Done
+packages/utils build: . build:node: DTS ⚡️ Build success in 2836ms
+packages/utils build: . build:node: DTS dist/node/index.d.ts 1.66 KB
+packages/utils build: . build:node: Done
+packages/utils build: . build:shared: DTS ⚡️ Build success in 3695ms
+packages/utils build: . build:shared: DTS dist/shared/index.d.ts 8.67 KB
+packages/utils build: . build:shared: Done
+packages/utils build: Done
+packages/env build$ tsup src/index.ts --format=esm --dts
+packages/memory build$ tsup src/index.ts --format=esm --dts
+packages/pressure build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-azure build$ tsup src/index.ts --format=esm --dts
+packages/pressure build: CLI Building entry: src/index.ts
+packages/pressure build: CLI Using tsconfig: tsconfig.json
+packages/pressure build: CLI tsup v8.4.0
+packages/env build: CLI Building entry: src/index.ts
+packages/pressure build: CLI Target: es2022
+packages/env build: CLI Using tsconfig: tsconfig.json
+packages/env build: CLI tsup v8.4.0
+packages/memory build: CLI Building entry: src/index.ts
+packages/pressure build: ESM Build start
+packages/memory build: CLI Using tsconfig: tsconfig.json
+packages/memory build: CLI tsup v8.4.0
+packages/env build: CLI Target: es2022
+packages/memory build: CLI Target: es2022
+packages/env build: ESM Build start
+packages/memory build: ESM Build start
+packages/storage-driver-azure build: CLI Building entry: src/index.ts
+packages/storage-driver-azure build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-azure build: CLI tsup v8.4.0
+packages/pressure build: ESM dist/index.js 2.25 KB
+packages/pressure build: ESM ⚡️ Build success in 59ms
+packages/storage-driver-azure build: CLI Target: es2022
+packages/storage-driver-azure build: ESM Build start
+packages/memory build: ESM dist/index.js 13.57 KB
+packages/memory build: ESM ⚡️ Build success in 104ms
+packages/storage-driver-azure build: ESM dist/index.js 3.74 KB
+packages/storage-driver-azure build: ESM ⚡️ Build success in 57ms
+packages/env build: ESM dist/index.js 17.72 KB
+packages/env build: ESM ⚡️ Build success in 124ms
+packages/pressure build: DTS Build start
+packages/env build: DTS Build start
+packages/storage-driver-azure build: DTS Build start
+packages/memory build: DTS Build start
+packages/pressure build: DTS ⚡️ Build success in 3436ms
+packages/pressure build: DTS dist/index.d.ts 885.00 B
+packages/pressure build: Done
+packages/storage-driver-cloudinary build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-azure build: DTS ⚡️ Build success in 3543ms
+packages/storage-driver-azure build: DTS dist/index.d.ts 1.52 KB
+packages/storage-driver-azure build: Done
+packages/storage-driver-gcs build$ tsup src/index.ts --format=esm --dts
+packages/env build: DTS ⚡️ Build success in 3652ms
+packages/env build: DTS dist/index.d.ts 90.00 B
+packages/env build: Done
+packages/storage-driver-s3 build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-cloudinary build: CLI Building entry: src/index.ts
+packages/storage-driver-cloudinary build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-cloudinary build: CLI tsup v8.4.0
+packages/storage-driver-cloudinary build: CLI Target: es2022
+packages/storage-driver-cloudinary build: ESM Build start
+packages/storage-driver-cloudinary build: ESM dist/index.js 13.81 KB
+packages/storage-driver-cloudinary build: ESM ⚡️ Build success in 42ms
+packages/storage-driver-gcs build: CLI Building entry: src/index.ts
+packages/storage-driver-gcs build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-gcs build: CLI tsup v8.4.0
+packages/storage-driver-gcs build: CLI Target: es2022
+packages/storage-driver-gcs build: ESM Build start
+packages/memory build: DTS ⚡️ Build success in 4115ms
+packages/memory build: DTS dist/index.d.ts 13.45 KB
+packages/storage-driver-gcs build: ESM dist/index.js 3.54 KB
+packages/storage-driver-gcs build: ESM ⚡️ Build success in 65ms
+packages/memory build: Done
+packages/storage-driver-supabase build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-s3 build: CLI Building entry: src/index.ts
+packages/storage-driver-s3 build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-s3 build: CLI tsup v8.4.0
+packages/storage-driver-s3 build: CLI Target: es2022
+packages/storage-driver-s3 build: ESM Build start
+packages/storage-driver-s3 build: ESM dist/index.js 12.19 KB
+packages/storage-driver-s3 build: ESM ⚡️ Build success in 30ms
+packages/storage-driver-cloudinary build: DTS Build start
+packages/storage-driver-gcs build: DTS Build start
+packages/storage-driver-supabase build: CLI Building entry: src/index.ts
+packages/storage-driver-supabase build: CLI Using tsconfig: tsconfig.json
+packages/storage-driver-supabase build: CLI tsup v8.4.0
+packages/storage-driver-supabase build: CLI Target: es2022
+packages/storage-driver-supabase build: ESM Build start
+packages/storage-driver-s3 build: DTS Build start
+packages/storage-driver-supabase build: ESM dist/index.js 6.46 KB
+packages/storage-driver-supabase build: ESM ⚡️ Build success in 158ms
+packages/storage-driver-supabase build: DTS Build start
+packages/storage-driver-cloudinary build: DTS ⚡️ Build success in 3578ms
+packages/storage-driver-cloudinary build: DTS dist/index.d.ts 2.85 KB
+packages/storage-driver-cloudinary build: Done
+packages/themes build$ vite build
+packages/storage-driver-gcs build: DTS ⚡️ Build success in 4039ms
+packages/storage-driver-gcs build: DTS dist/index.d.ts 1.46 KB
+packages/storage-driver-gcs build: Done
+packages/validation build$ tsup src/index.ts --format=esm --dts
+packages/storage-driver-supabase build: DTS ⚡️ Build success in 3255ms
+packages/storage-driver-supabase build: DTS dist/index.d.ts 1.76 KB
+packages/storage-driver-supabase build: Done
+packages/validation build: CLI Building entry: src/index.ts
+packages/validation build: CLI Using tsconfig: tsconfig.json
+packages/validation build: CLI tsup v8.4.0
+packages/validation build: CLI Target: es2022
+packages/validation build: ESM Build start
+packages/validation build: ESM dist/index.js 5.55 KB
+packages/validation build: ESM ⚡️ Build success in 48ms
+packages/storage-driver-s3 build: DTS ⚡️ Build success in 4640ms
+packages/storage-driver-s3 build: DTS dist/index.d.ts 2.08 KB
+packages/storage-driver-s3 build: Done
+packages/validation build: DTS Build start
+packages/themes build: vite v5.4.19 building for production...
+packages/validation build: DTS ⚡️ Build success in 2587ms
+packages/validation build: DTS dist/index.d.ts 774.00 B
+packages/validation build: Done
+packages/themes build: transforming...
+packages/themes build: Failed
+/workspace/directus/packages/themes:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @directus/themes@1.1.2 build: `vite build`
+Exit status 129
+ ELIFECYCLE  Command failed with exit code 129.

--- a/logs/pnpm_install_pass56.log
+++ b/logs/pnpm_install_pass56.log
@@ -1,0 +1,175 @@
+Scope: all 43 workspace projects
+ WARN  There are cyclic workspace dependencies: /workspace/directus/api, /workspace/directus/directus
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Packages: +2332
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+   ╭───────────────────────────────────────────────────────────────────╮
+   │                                                                   │
+   │                Update available! 9.15.6 → 10.13.1.                │
+   │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v10.13.1   │
+   │            Run "corepack use pnpm@10.13.1" to update.             │
+   │                                                                   │
+   ╰───────────────────────────────────────────────────────────────────╯
+
+Progress: resolved 2332, reused 0, downloaded 5, added 0
+Progress: resolved 2332, reused 0, downloaded 33, added 23
+Progress: resolved 2332, reused 0, downloaded 84, added 83
+Progress: resolved 2332, reused 0, downloaded 135, added 129
+Progress: resolved 2332, reused 0, downloaded 184, added 177
+Progress: resolved 2332, reused 0, downloaded 276, added 269
+Progress: resolved 2332, reused 0, downloaded 326, added 325
+Progress: resolved 2332, reused 0, downloaded 403, added 403
+Progress: resolved 2332, reused 0, downloaded 492, added 492
+Progress: resolved 2332, reused 0, downloaded 551, added 547
+Progress: resolved 2332, reused 0, downloaded 606, added 606
+Progress: resolved 2332, reused 0, downloaded 683, added 680
+Progress: resolved 2332, reused 0, downloaded 702, added 697
+Progress: resolved 2332, reused 0, downloaded 787, added 784
+Progress: resolved 2332, reused 0, downloaded 863, added 855
+Progress: resolved 2332, reused 0, downloaded 932, added 930
+Progress: resolved 2332, reused 0, downloaded 986, added 984
+Progress: resolved 2332, reused 0, downloaded 1042, added 1040
+Progress: resolved 2332, reused 0, downloaded 1105, added 1103
+Progress: resolved 2332, reused 0, downloaded 1161, added 1161
+Progress: resolved 2332, reused 0, downloaded 1226, added 1224
+Progress: resolved 2332, reused 0, downloaded 1277, added 1274
+Progress: resolved 2332, reused 0, downloaded 1351, added 1349
+Progress: resolved 2332, reused 0, downloaded 1380, added 1379
+Progress: resolved 2332, reused 0, downloaded 1426, added 1424
+Progress: resolved 2332, reused 0, downloaded 1478, added 1476
+Progress: resolved 2332, reused 0, downloaded 1552, added 1553
+Progress: resolved 2332, reused 0, downloaded 1610, added 1608
+Progress: resolved 2332, reused 0, downloaded 1630, added 1631
+Progress: resolved 2332, reused 0, downloaded 1665, added 1663
+Progress: resolved 2332, reused 0, downloaded 1698, added 1698
+Progress: resolved 2332, reused 0, downloaded 1699, added 1698
+Progress: resolved 2332, reused 0, downloaded 1755, added 1750
+Progress: resolved 2332, reused 0, downloaded 1815, added 1815
+Progress: resolved 2332, reused 0, downloaded 1897, added 1897
+Progress: resolved 2332, reused 0, downloaded 1962, added 1959
+Progress: resolved 2332, reused 0, downloaded 2019, added 2016
+Progress: resolved 2332, reused 0, downloaded 2058, added 2057
+Progress: resolved 2332, reused 0, downloaded 2113, added 2110
+Progress: resolved 2332, reused 0, downloaded 2160, added 2161
+Progress: resolved 2332, reused 0, downloaded 2225, added 2224
+Progress: resolved 2332, reused 0, downloaded 2291, added 2289
+Progress: resolved 2332, reused 0, downloaded 2331, added 2332, done
+.../node_modules/@parcel/watcher install$ node scripts/build-from-source.js
+.../sqlite3@5.1.7/node_modules/sqlite3 install$ prebuild-install -r napi || node-gyp rebuild
+.../esbuild@0.21.5/node_modules/esbuild postinstall$ node install.js
+.../node_modules/isolated-vm install$ prebuild-install || (node-gyp rebuild --release -j max && node-gyp clean)
+.../argon2@0.41.1/node_modules/argon2 install$ node-gyp-build
+.../node_modules/@parcel/watcher install: Done
+.../esbuild@0.21.5/node_modules/esbuild postinstall: Done
+.../sharp@0.33.5/node_modules/sharp install$ node install/check
+.../sqlite3@5.1.7/node_modules/sqlite3 install: prebuild-install warn This package does not support N-API version undefined
+.../argon2@0.41.1/node_modules/argon2 install: Done
+.../oracledb@6.8.0/node_modules/oracledb install$ node package/install.js
+.../esbuild@0.25.0/node_modules/esbuild postinstall$ node install.js
+.../sharp@0.33.5/node_modules/sharp install: Done
+.../fontawesome-common-types postinstall$ node attribution.js
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ********************************************************************************
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ** Node-oracledb 6.8.0 installed in Node.js 22.16.0 (linux, x64)
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ** To use node-oracledb in Thin mode, no additional steps are needed.
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ** To use the optional Thick mode, the Oracle Client libraries (64-bit)
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ** must be available, see the installation instructions:
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb **   https://node-oracledb.readthedocs.io/en/latest/user_guide/installation.html#node-oracledb-installation-on-linux
+.../oracledb@6.8.0/node_modules/oracledb install: oracledb ********************************************************************************
+.../oracledb@6.8.0/node_modules/oracledb install: Done
+.../esbuild@0.25.0/node_modules/esbuild postinstall: Done
+.../fontawesome-common-types postinstall: Font Awesome Free 0.2.36 by @fontawesome - https://fontawesome.com
+.../fontawesome-common-types postinstall: License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+.../fontawesome-common-types postinstall: Done
+.../node_modules/vue-demi postinstall$ node -e "try{require('./scripts/postinstall.js')}catch(e){}"
+.../sqlite3@5.1.7/node_modules/sqlite3 install: prebuild-install warn install No prebuilt binaries found (target=undefined runtime=napi arch=x64 libc= platform=linux)
+.../esbuild@0.18.20/node_modules/esbuild postinstall$ node install.js
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info it worked if it ends with ok
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info using node-gyp@8.4.1
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info using node@22.16.0 | linux | x64
+.../node_modules/vue-demi postinstall: Done
+.../esbuild@0.18.20/node_modules/esbuild postinstall: Done
+.../sqlite3@5.1.7/node_modules/sqlite3 install: (node:15378) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
+.../sqlite3@5.1.7/node_modules/sqlite3 install: (Use `node --trace-deprecation ...` to show where the warning was created)
+.../node_modules/isolated-vm install: Done
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info find Python using Python version 3.12.10 found at "/root/.pyenv/versions/3.12.10/bin/python3"
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp http GET https://nodejs.org/download/release/v22.16.0/node-v22.16.0-headers.tar.gz
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp http 200 https://nodejs.org/download/release/v22.16.0/node-v22.16.0-headers.tar.gz
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp http GET https://nodejs.org/download/release/v22.16.0/SHASUMS256.txt
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp http 200 https://nodejs.org/download/release/v22.16.0/SHASUMS256.txt
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn /root/.pyenv/versions/3.12.10/bin/python3
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args [
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/gyp/gyp_main.py',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   'binding.gyp',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-f',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   'make',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-I',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '/workspace/directus/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/build/config.gypi',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-I',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/addon.gypi',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-I',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '/root/.cache/node-gyp/22.16.0/include/node/common.gypi',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dlibrary=shared_library',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dvisibility=default',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/22.16.0',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dnode_gyp_dir=/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/22.16.0/<(target_arch)/node.lib',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dmodule_root_dir=/workspace/directus/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Dnode_engine=v8',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '--depth=.',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '--no-parallel',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '--generator-output',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   'build',
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args   '-Goutput_dir=.'
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp info spawn args ]
+.../sqlite3@5.1.7/node_modules/sqlite3 install: Traceback (most recent call last):
+.../sqlite3@5.1.7/node_modules/sqlite3 install:   File "/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/gyp/gyp_main.py", line 42, in <module>
+.../sqlite3@5.1.7/node_modules/sqlite3 install:     import gyp  # noqa: E402
+.../sqlite3@5.1.7/node_modules/sqlite3 install:     ^^^^^^^^^^
+.../sqlite3@5.1.7/node_modules/sqlite3 install:   File "/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 9, in <module>
+.../sqlite3@5.1.7/node_modules/sqlite3 install:     import gyp.input
+.../sqlite3@5.1.7/node_modules/sqlite3 install:   File "/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
+.../sqlite3@5.1.7/node_modules/sqlite3 install:     from distutils.version import StrictVersion
+.../sqlite3@5.1.7/node_modules/sqlite3 install: ModuleNotFoundError: No module named 'distutils'
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! configure error 
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! stack Error: `gyp` failed with exit code: 1
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! stack     at ChildProcess.onCpExit (/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/lib/configure.js:259:16)
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! stack     at ChildProcess.emit (node:events:518:28)
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:293:12)
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! System Linux 6.12.13
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! command "/root/.nvm/versions/node/v22.16.0/bin/node" "/workspace/directus/node_modules/.pnpm/node-gyp@8.4.1/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! cwd /workspace/directus/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! node -v v22.16.0
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! node-gyp -v v8.4.1
+.../sqlite3@5.1.7/node_modules/sqlite3 install: gyp ERR! not ok 
+.../sqlite3@5.1.7/node_modules/sqlite3 install: Failed
+.../@fortawesome/fontawesome-svg-core postinstall$ node attribution.js
+.../@fortawesome/free-solid-svg-icons postinstall$ node attribution.js
+.../@fortawesome/free-regular-svg-icons postinstall$ node attribution.js
+.../@fortawesome/fontawesome-svg-core postinstall: Font Awesome Free 1.2.36 by @fontawesome - https://fontawesome.com
+.../@fortawesome/fontawesome-svg-core postinstall: License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+.../@fortawesome/fontawesome-svg-core postinstall: Done
+.../@fortawesome/free-solid-svg-icons postinstall: Font Awesome Free 5.15.4 by @fontawesome - https://fontawesome.com
+.../@fortawesome/free-solid-svg-icons postinstall: License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+.../@fortawesome/free-solid-svg-icons postinstall: Done
+.../@fortawesome/free-regular-svg-icons postinstall: Font Awesome Free 5.15.4 by @fontawesome - https://fontawesome.com
+.../@fortawesome/free-regular-svg-icons postinstall: License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+.../@fortawesome/free-regular-svg-icons postinstall: Done
+
+devDependencies:
++ @changesets/cli 2.28.1
++ @directus/release-notes-generator 2.0.1 <- packages/release-notes-generator
++ @eslint/js 9.21.0
++ @vitest/coverage-v8 2.1.9
++ eslint 9.21.0
++ eslint-config-prettier 9.1.0
++ eslint-plugin-vue 9.32.0
++ globals 15.15.0
++ prettier 3.1.0
++ rimraf 6.0.1
++ typescript 5.8.2
++ typescript-eslint 8.25.0
++ vitest 2.1.9
+
+Done in 57.1s using pnpm v9.15.6

--- a/todo.md
+++ b/todo.md
@@ -56,3 +56,4 @@
 
 - [pass54] npm test fails with Axios 503 in @directus/api {status:open} {priority:medium}
 - [pass55] Add Keycloak auth extension and tests {status:done} {priority:low}
+- [pass56] Scaffold remaining Directus extensions {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -557,8 +557,8 @@
       "logs/pytest_pass53.log"
     ],
     "trigger": "test & resolve"
-  }
-  ,{
+  },
+  {
     "phase": "phase3",
     "pass": 55,
     "changes": [
@@ -569,5 +569,38 @@
       "todo.md"
     ],
     "trigger": "add keycloak auth"
+  },
+  {
+    "phase": "phase3",
+    "pass": 56,
+    "changes": [
+      "extensions/nucleus-crm/index.js",
+      "extensions/nucleus-crm/package.json",
+      "extensions/nucleus-contracts/index.js",
+      "extensions/nucleus-contracts/package.json",
+      "extensions/nucleus-docs/index.js",
+      "extensions/nucleus-docs/package.json",
+      "extensions/nucleus-edi/index.js",
+      "extensions/nucleus-edi/package.json",
+      "extensions/nucleus-support/index.js",
+      "extensions/nucleus-support/package.json",
+      "extensions/nucleus-tenable/index.js",
+      "extensions/nucleus-tenable/package.json",
+      "extensions/nucleus-sophos/index.js",
+      "extensions/nucleus-sophos/package.json",
+      "extensions/nucleus-portal/index.js",
+      "extensions/nucleus-portal/package.json",
+      "extensions/nucleus-dmarc/index.js",
+      "extensions/nucleus-dmarc/package.json",
+      "extensions/nucleus-ui/index.js",
+      "extensions/nucleus-ui/package.json",
+      "extensions/nucleus-api/index.js",
+      "extensions/nucleus-api/package.json",
+      "logs/pnpm_install_pass56.log",
+      "logs/npm_pass56.log",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "scaffold extensions"
   }
 ]


### PR DESCRIPTION
## Summary
- scaffold empty Directus extensions for upcoming CRM modules
- run pnpm install and npm test
- record failing extension install command in logs

## Testing
- `pnpm install`
- `npm test` *(fails in @directus/themes build)*

------
https://chatgpt.com/codex/tasks/task_e_687022c57fe48324884bf76ac0a9064b