### PR TITLE
Integrate CRM extensions into core tree

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -360,3 +360,7 @@
 - Scaffolded missing Directus extensions under `extensions/`.
 - Ran `npx directus extension install` for each; command not recognized.
 - Executed `pnpm install` and `npm test` (tests still failing in @directus/themes).
+\n## Phase 3 – Pass 57 (2025-07-15)
+- Migrated nucleus-auth and nucleus-mail-ingest from CRM to extensions.
+- Updated tests to load new extension paths.
+- npm test fails in @directus/api with exit code 129.

--- a/extensions/nucleus-auth/README.md
+++ b/extensions/nucleus-auth/README.md
@@ -1,0 +1,12 @@
+# Nucleus OAuth2 Extension
+
+This extension registers a Passport OAuth2 strategy to authenticate users via an external provider.
+
+Environment variables required:
+- `NUCLEUS_CLIENT_ID`
+- `NUCLEUS_SECRET`
+- `OAUTH_AUTH_URL`
+- `OAUTH_TOKEN_URL`
+- `OAUTH_CALLBACK_URL`
+
+Once installed, admins can configure the OAuth2 credentials under **Settings → Auth Provider** in the Directus admin panel. The login page shows a **Sign in with Nucleus** button for users.

--- a/extensions/nucleus-auth/index.js
+++ b/extensions/nucleus-auth/index.js
@@ -1,0 +1,22 @@
+import passport from 'passport';
+import { Strategy as OAuth2Strategy } from 'passport-oauth2';
+
+export default function register({ services }) {
+  const { logger } = services;
+
+  const strategy = new OAuth2Strategy(
+    {
+      authorizationURL: process.env.OAUTH_AUTH_URL,
+      tokenURL: process.env.OAUTH_TOKEN_URL,
+      clientID: process.env.NUCLEUS_CLIENT_ID,
+      clientSecret: process.env.NUCLEUS_SECRET,
+      callbackURL: process.env.OAUTH_CALLBACK_URL,
+    },
+    function verify(accessToken, refreshToken, profile, done) {
+      return done(null, profile);
+    }
+  );
+
+  passport.use('nucleus-oauth', strategy);
+  logger.info('Nucleus OAuth2 extension loaded');
+}

--- a/extensions/nucleus-auth/package.json
+++ b/extensions/nucleus-auth/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nucleus-auth",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "passport": "^0.6.0",
+    "passport-oauth2": "^1.6.1"
+  }
+}

--- a/extensions/nucleus-mail-ingest/README.md
+++ b/extensions/nucleus-mail-ingest/README.md
@@ -1,0 +1,10 @@
+# Nucleus Mail Ingest Extension
+
+Connects to an IMAP server every hour and parses incoming XML messages.
+
+Required environment variables:
+- `IMAP_HOST`
+- `IMAP_USER`
+- `IMAP_PASSWORD`
+
+Admins manage the connection settings under **Support → Mail Ingest**. Parsed messages are stored as tickets in the support module.

--- a/extensions/nucleus-mail-ingest/index.js
+++ b/extensions/nucleus-mail-ingest/index.js
@@ -1,0 +1,35 @@
+import imaps from 'imap-simple';
+import { parseStringPromise } from 'xml2js';
+
+export default function register({ schedule, services }) {
+  const { logger } = services;
+  schedule('0 * * * *', async () => {
+    const config = {
+      imap: {
+        user: process.env.IMAP_USER,
+        password: process.env.IMAP_PASSWORD,
+        host: process.env.IMAP_HOST,
+        port: 993,
+        tls: true,
+        authTimeout: 3000,
+      },
+    };
+    try {
+      const connection = await imaps.connect(config);
+      await connection.openBox('INBOX');
+      const results = await connection.search(['UNSEEN'], { bodies: [''] });
+      for (const res of results) {
+        const all = res.parts.find((p) => p.which === '');
+        try {
+          const parsed = await parseStringPromise(all.body);
+          logger.info('Parsed XML email', parsed);
+        } catch (err) {
+          logger.error('Failed to parse email', err);
+        }
+      }
+      await connection.end();
+    } catch (err) {
+      logger.error('IMAP connection error', err);
+    }
+  });
+}

--- a/extensions/nucleus-mail-ingest/package.json
+++ b/extensions/nucleus-mail-ingest/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nucleus-mail-ingest",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "imap-simple": "^5.0.0",
+    "xml2js": "^0.4.23"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2207,6 +2207,8 @@ importers:
 
   tests/build-memory: {}
 
+  tests/keycloak-auth: {}
+
   tests/nucleus-auth:
     dependencies:
       passport:

--- a/tests/nucleus-auth/auth.test.mjs
+++ b/tests/nucleus-auth/auth.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import passport from 'passport';
-import register from '../../CRM/extensions/nucleus-auth/index.js';
+import register from '../../extensions/nucleus-auth/index.js';
 
 // Reset strategy before each run
 passport.unuse('nucleus-oauth');

--- a/tests/nucleus-mail-ingest/ingest.test.mjs
+++ b/tests/nucleus-mail-ingest/ingest.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import register from '../../CRM/extensions/nucleus-mail-ingest/index.js';
+import register from '../../extensions/nucleus-mail-ingest/index.js';
 
 let cronExp;
 const schedule = (exp, fn) => { cronExp = exp; };

--- a/todo.md
+++ b/todo.md
@@ -57,3 +57,4 @@
 - [pass54] npm test fails with Axios 503 in @directus/api {status:open} {priority:medium}
 - [pass55] Add Keycloak auth extension and tests {status:done} {priority:low}
 - [pass56] Scaffold remaining Directus extensions {status:done} {priority:low}
+- [pass57] Migrated auth/mail ingest extensions to root {status:done} {priority:low}


### PR DESCRIPTION
## Summary
- move nucleus-auth and nucleus-mail-ingest extensions from CRM into `extensions/`
- update tests to reference the new paths
- document the migration in the changelog and todo

## Testing
- `pnpm install`
- `pnpm --filter @directus/random run build`
- `pnpm --filter @directus/storage run build`
- `npm test` *(fails: `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'sqlalchemy'`)*

------
https://chatgpt.com/codex/tasks/task_e_687033953ae083249c115361229d645f