### PR TITLE
Implement docs and portal extensions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -371,3 +371,14 @@
 - Installed Python backend requirements so pytest finds sqlalchemy.
 - All 94 Python tests pass.
 - `npm test` still fails in `@directus/extensions-sdk` with exit code 129.
+
+## Phase 3 – Pass 60 (2025-09-09)
+- Replaced Keycloak auth placeholder with real token exchange logic.
+- Updated docs and tests for new Keycloak integration.
+- `npm test` fails building @directus/app (exit code 129).
+
+## Phase 3 – Pass 61 (2025-09-09)
+- Implemented initial logic for nucleus-docs, nucleus-edi and nucleus-portal extensions.
+- Added PDF and CSV generation endpoint, EDI XML parsing, and public frontpage route.
+- Updated extension package.json files with required dependencies.
+- `npm test` fails in @directus/app with exit code 129.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -3,6 +3,7 @@
 This folder is reserved for Directus extensions that are independent from the CRM modules under `CRM/extensions`.
 Place custom interfaces, modules or plugins here so Directus can load them automatically.
 
-This workspace now contains a simple Keycloak authentication extension under
-`extensions/auth/keycloak`. It overrides the login flow and serves as a placeholder
-for full SSO integration. See `docs/inventory.md` for other planned packages.
+This workspace now contains a Keycloak authentication extension under
+`extensions/auth/keycloak`. It implements a login flow that exchanges the user's
+credentials for a token via the configured Keycloak server before delegating to
+Directus. See `docs/inventory.md` for other planned packages.

--- a/extensions/auth/keycloak/index.js
+++ b/extensions/auth/keycloak/index.js
@@ -1,7 +1,27 @@
 export default function registerKeycloakAuth({ init }) {
   init('auth', ({ authentication }) => {
     authentication.login = async function (credentials) {
-      console.log('Keycloak login placeholder for', credentials.email);
+      const baseUrl = process.env.KEYCLOAK_URL;
+      if (!baseUrl) {
+        throw new Error('KEYCLOAK_URL not configured');
+      }
+      const params = new URLSearchParams({
+        grant_type: 'password',
+        client_id: process.env.KEYCLOAK_CLIENT_ID ?? 'directus',
+        client_secret: process.env.KEYCLOAK_CLIENT_SECRET ?? '',
+        username: credentials.email,
+        password: credentials.password,
+      });
+      const res = await fetch(`${baseUrl}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+      if (!res.ok) {
+        throw new Error(`Keycloak login failed: ${res.status}`);
+      }
+      const data = await res.json();
+      credentials.access_token = data.access_token;
       return this.loginWithCredentials(credentials);
     };
   });

--- a/extensions/nucleus-docs/index.js
+++ b/extensions/nucleus-docs/index.js
@@ -1,1 +1,24 @@
-export default function register() {}
+import PDFDocument from 'pdfkit';
+import { stringify } from 'csv-stringify/sync';
+
+export default function register({ init }) {
+  init('routes', ({ app }) => {
+    app.post('/docs/generate', async (req, res) => {
+      const { type, data } = req.body ?? {};
+      if (type === 'pdf') {
+        const doc = new PDFDocument();
+        const chunks = [];
+        doc.on('data', (c) => chunks.push(c));
+        doc.text(JSON.stringify(data, null, 2));
+        doc.end();
+        await new Promise((r) => doc.on('end', r));
+        res.type('application/pdf').send(Buffer.concat(chunks));
+      } else if (type === 'csv') {
+        const csv = stringify(data || []);
+        res.type('text/csv').send(csv);
+      } else {
+        res.status(400).json({ error: 'unknown type' });
+      }
+    });
+  });
+}

--- a/extensions/nucleus-docs/package.json
+++ b/extensions/nucleus-docs/package.json
@@ -2,5 +2,9 @@
   "name": "nucleus-docs",
   "version": "0.1.0",
   "main": "index.js",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "pdfkit": "^0.13.0",
+    "csv-stringify": "^6.4.0"
+  }
 }

--- a/extensions/nucleus-edi/index.js
+++ b/extensions/nucleus-edi/index.js
@@ -1,1 +1,17 @@
-export default function register() {}
+import { parseStringPromise } from 'xml2js';
+
+export default function register({ init, services }) {
+  const { logger } = services;
+  init('routes', ({ app }) => {
+    app.post('/edi/parse', async (req, res) => {
+      try {
+        const json = await parseStringPromise(req.body);
+        logger.info('Received EDI', json);
+        res.json(json);
+      } catch (err) {
+        logger.error('EDI parse error', err);
+        res.status(400).json({ error: 'invalid xml' });
+      }
+    });
+  });
+}

--- a/extensions/nucleus-edi/package.json
+++ b/extensions/nucleus-edi/package.json
@@ -2,5 +2,8 @@
   "name": "nucleus-edi",
   "version": "0.1.0",
   "main": "index.js",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "xml2js": "^0.6.2"
+  }
 }

--- a/extensions/nucleus-portal/index.js
+++ b/extensions/nucleus-portal/index.js
@@ -1,1 +1,7 @@
-export default function register() {}
+export default function register({ init }) {
+  init('routes', ({ app }) => {
+    app.get('/core/frontpage', (_req, res) => {
+      res.type('html').send('<h1>Nucleus Portal</h1><p>Welcome to Nucleus.</p>');
+    });
+  });
+}

--- a/tests/keycloak-auth/keycloak.test.mjs
+++ b/tests/keycloak-auth/keycloak.test.mjs
@@ -1,11 +1,27 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import register from '../../extensions/auth/keycloak/index.js';
+
 let called = false;
-const auth = { loginWithCredentials: async () => { called = true; } };
-const init = (_name, fn) => { fn({ authentication: auth }); };
+const auth = {
+  loginWithCredentials: async (creds) => {
+    if (creds.access_token === 'abc123') {
+      called = true;
+    }
+  },
+};
+
+global.fetch = async () => ({ ok: true, json: async () => ({ access_token: 'abc123' }) });
+process.env.KEYCLOAK_URL = 'http://kc';
+
+const init = (_name, fn) => {
+  fn({ authentication: auth });
+};
+
 register({ init });
-await auth.login({ email: 'a@example.com' }).catch(() => {});
-await test('keycloak auth overrides login', () => {
+
+await auth.login({ email: 'a@example.com', password: 'pw' });
+
+await test('keycloak auth fetches token and logs in', () => {
   assert.ok(called);
 });

--- a/todo.md
+++ b/todo.md
@@ -60,3 +60,5 @@
 - [pass57] Migrated auth/mail ingest extensions to root {status:done} {priority:low}
 - [pass58] Document full implementation plan for remaining extensions {status:done} {priority:low}
 - [pass59] Install Python requirements to fix sqlalchemy error {status:done} {priority:low}
+- [pass60] Replace placeholder Keycloak auth with real token exchange {status:done} {priority:low}
+- [pass61] Flesh out docs, edi and portal extensions {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -621,5 +621,29 @@
       "todo.md"
     ],
     "trigger": "fix pytest"
+  },
+  {
+    "pass": 60,
+    "files": [
+      "extensions/auth/keycloak/index.js",
+      "extensions/README.md",
+      "tests/keycloak-auth/keycloak.test.mjs",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "replace placeholder keycloak auth"
+  },
+  {
+    "pass": 61,
+    "files": [
+      "extensions/nucleus-docs/index.js",
+      "extensions/nucleus-docs/package.json",
+      "extensions/nucleus-edi/index.js",
+      "extensions/nucleus-edi/package.json",
+      "extensions/nucleus-portal/index.js",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "implement docs, edi and portal extensions"
   }
 ]


### PR DESCRIPTION
## Summary
- add PDF/CSV generation endpoint in nucleus-docs
- implement EDI XML parser in nucleus-edi
- provide basic /core/frontpage route from nucleus-portal
- log updates in changelog, todo and trace

## Testing
- `pnpm install`
- `NODE_OPTIONS=--max_old_space_size=8192 npm test` *(fails building @directus/app with exit code 129)*

------
https://chatgpt.com/codex/tasks/task_e_68711083d88083248a48884377b1a704