### PR TITLE
[CORE] add docs extension tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -382,3 +382,7 @@
 - Added PDF and CSV generation endpoint, EDI XML parsing, and public frontpage route.
 - Updated extension package.json files with required dependencies.
 - `npm test` fails in @directus/app with exit code 129.
+
+## Phase 3 – Pass 62 (2025-09-09)
+- Added tests for nucleus-docs extension.
+- `npm test` fails building @directus/app (exit code 129).

--- a/logs/autofix_trace.json
+++ b/logs/autofix_trace.json
@@ -1,0 +1,3 @@
+[
+  {"pass": 62, "action": "added docs tests"}
+]

--- a/logs/dev_progress.json
+++ b/logs/dev_progress.json
@@ -1,0 +1,3 @@
+[
+  {"pass": 62, "timestamp": "2025-07-12T12:34:31+00:00", "notes": "Added docs extension tests"}
+]

--- a/logs/test_matrix.json
+++ b/logs/test_matrix.json
@@ -1,0 +1,3 @@
+[
+  {"pass": 62, "npm": "fail", "details": "@directus/app build exited with 129"}
+]

--- a/tests/nucleus-docs/docs.test.mjs
+++ b/tests/nucleus-docs/docs.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import register from '../../extensions/nucleus-docs/index.js';
+
+let route;
+const app = { post: (_path, cb) => { route = cb; } };
+const init = (_name, fn) => { fn({ app }); };
+
+register({ init });
+
+test('generate csv', async () => {
+  let mime;
+  let sent;
+  const res = {
+    type: (m) => { mime = m; return res; },
+    send: (d) => { sent = d; }
+  };
+  await route({ body: { type: 'csv', data: [{ id: 1 }] } }, res);
+  assert.equal(mime, 'text/csv');
+  assert.match(String(sent), /id/);
+});
+
+test('generate pdf', async () => {
+  let mime;
+  let len = 0;
+  const res = {
+    type: (m) => { mime = m; return res; },
+    send: (d) => { len = d.length; }
+  };
+  await route({ body: { type: 'pdf', data: { hello: 'world' } } }, res);
+  assert.equal(mime, 'application/pdf');
+  assert.ok(len > 0);
+});

--- a/tests/nucleus-docs/package.json
+++ b/tests/nucleus-docs/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "pdfkit": "^0.15.0",
+    "csv-stringify": "^6.5.0"
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -62,3 +62,5 @@
 - [pass59] Install Python requirements to fix sqlalchemy error {status:done} {priority:low}
 - [pass60] Replace placeholder Keycloak auth with real token exchange {status:done} {priority:low}
 - [pass61] Flesh out docs, edi and portal extensions {status:done} {priority:low}
+
+- [pass62] Add tests for nucleus-docs extension {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -645,5 +645,15 @@
       "todo.md"
     ],
     "trigger": "implement docs, edi and portal extensions"
+  },
+  {
+    "pass": 62,
+    "files": [
+      "tests/nucleus-docs/docs.test.mjs",
+      "tests/nucleus-docs/package.json",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "add tests for nucleus-docs"
   }
 ]


### PR DESCRIPTION
## Summary
- add `nucleus-docs` tests covering CSV and PDF generation
- document the change in `changelog.md`
- track the update in `todo.md` and `trace.json`
- log progress and test results

## Testing
- `npm test` *(fails: @directus/app build exited with code 129)*

------
https://chatgpt.com/codex/tasks/task_e_687253c163708324b0211665aa52c7bc