### PR TITLE
Add extension check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ cannot resolve workspace protocols.
 `npm install` is not supported at the repository root because the monorepo uses
 the `workspace:` protocol. Use `pnpm install` or run `scripts/install.sh` to
 install all dependencies.
+### Verifying extension structure
+Run `node extensions/check_extensions.cjs` to list each extension and verify that required files are present.
+
 
 ### Node.js 18 Compatibility
 

--- a/changelog.md
+++ b/changelog.md
@@ -386,3 +386,6 @@
 ## Phase 3 – Pass 62 (2025-09-09)
 - Added tests for nucleus-docs extension.
 - `npm test` fails building @directus/app (exit code 129).
+## Phase 3 – Pass 63 (2025-09-09)
+- Added check_extensions.cjs script to validate extension files.
+- Verified extensions via new script and ran `npm test`, which still fails building @directus/app (exit code 129).

--- a/extensions/check_extensions.cjs
+++ b/extensions/check_extensions.cjs
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = __dirname;
+
+function checkDir(dirName, parent = '') {
+  const full = path.join(baseDir, parent, dirName);
+  const hasIndex = fs.existsSync(path.join(full, 'index.js'));
+  const hasPackage = fs.existsSync(path.join(full, 'package.json'));
+  console.log(`${parent}${dirName}: index.js ${hasIndex ? '✔' : '✖'} package.json ${hasPackage ? '✔' : '✖'}`);
+}
+
+for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  if (entry.name === 'auth') {
+    for (const sub of fs.readdirSync(path.join(baseDir, 'auth'), { withFileTypes: true })) {
+      if (sub.isDirectory()) checkDir(sub.name, 'auth/');
+    }
+  } else {
+    checkDir(entry.name);
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -64,3 +64,4 @@
 - [pass61] Flesh out docs, edi and portal extensions {status:done} {priority:low}
 
 - [pass62] Add tests for nucleus-docs extension {status:done} {priority:low}
+- [pass63] Verify extension structure and note npm test failure (exit code 129)

--- a/trace.json
+++ b/trace.json
@@ -655,5 +655,15 @@
       "todo.md"
     ],
     "trigger": "add tests for nucleus-docs"
+  },
+  {
+    "pass": 63,
+    "files": [
+      "extensions/check_extensions.cjs",
+      "README.md",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "verify extensions and run tests"
   }
 ]


### PR DESCRIPTION
## Summary
- add `check_extensions.cjs` to verify extension folder structure
- document how to run the script in README
- note verification in changelog and todo
- log trace entry for pass 63

## Testing
- `pnpm install`
- `npm test` *(fails at @directus/app build)*
- `node extensions/check_extensions.cjs`

------
https://chatgpt.com/codex/tasks/task_e_687261b993e08324a6974a23e80114bb