### PR TITLE
Configure mise for Node idiomatic file

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]

--- a/changelog.md
+++ b/changelog.md
@@ -393,3 +393,13 @@
 - Added schema and token verification tests for nucleus-auth.
 - Initialized auth extension log file.
 
+## Phase 3 – Pass 65 (2025-09-10)
+- Implemented role mapping and token exchange route in nucleus-auth.
+- Added additional tests for role mapping and token exchange.
+- `npm test` still fails in @directus/extensions-sdk (exit code 129).
+
+
+## Phase 3 – Pass 66 (2025-09-10)
+- Configured mise idiomatic version file support via .mise.toml.
+- `npm test` still fails building @directus/app (exit code 129).
+

--- a/tests/nucleus-auth/auth.test.mjs
+++ b/tests/nucleus-auth/auth.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import passport from 'passport';
-import register, { verifyToken } from '../../extensions/nucleus-auth/index.js';
+import register, { verifyToken, mapRole, exchangeToken } from '../../extensions/nucleus-auth/index.js';
 
 // Reset strategy before each run
 passport.unuse('nucleus-oauth');
@@ -28,4 +28,15 @@ test('invalid token', () => {
 test('valid token', () => {
   const user = verifyToken('validtoken');
   assert.equal(user.role, 'admin');
+});
+
+test('role mapping', () => {
+  assert.equal(mapRole('admin'), 'administrator');
+  assert.equal(mapRole('unknown'), 'public');
+});
+
+test('token exchange', async () => {
+  const data = await exchangeToken('good');
+  assert.equal(data.access_token, 'validtoken');
+  await assert.rejects(() => exchangeToken('bad'));
 });

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 # TODO
 
 ## nucleus-auth
-- Create authentication schema {status:in-progress} {priority:high} {blocked_by:none}
+- Create authentication schema {status:done} {priority:high} {blocked_by:none}
 
 ## nucleus-core
 - Register each CRM extension in install.sh {status:done} {priority:medium} {blocked_by:none}
@@ -66,3 +66,5 @@
 - [pass62] Add tests for nucleus-docs extension {status:done} {priority:low}
 - [pass63] Verify extension structure and note npm test failure (exit code 129)
 - [pass64] Add auth schema and token tests {status:done} {priority:low}
+- [pass65] Add role mapping and token exchange route {status:done} {priority:low}
+- [pass66] Configure mise to honor .nvmrc {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -676,5 +676,24 @@
       "todo.md"
     ],
     "trigger": "add auth schema and tests"
+  },
+  {
+    "pass": 65,
+    "files": [
+      "extensions/nucleus-auth/index.js",
+      "tests/nucleus-auth/auth.test.mjs",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "add role mapping and exchange route"
+  },
+  {
+    "pass": 66,
+    "files": [
+      ".mise.toml",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "enable idiomatic version files"
   }
 ]


### PR DESCRIPTION
## Summary
- add `.mise.toml` enabling idiomatic version files for Node
- record new pass in changelog, todo, and trace

## Testing
- `pnpm install`
- `npm test` *(fails: exit code 129 during `vite build`)*

------
https://chatgpt.com/codex/tasks/task_e_6872b9dcb82c83248eb1524306e3002a