### PR TITLE
Fix nucleus-ui theme placeholder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -423,3 +423,7 @@
 ## Phase 3 – Pass 70 (2025-09-10)
 - Marked CRM directory as legacy; updated README and docs.
 - pnpm install and npm test still fail during app build.
+## Phase 3 – Pass 71 (2025-09-10)
+- Replaced placeholder CSS in nucleus-ui extension with env-driven theme.
+- Added unit test for theme route.
+

--- a/extensions/nucleus-ui/index.js
+++ b/extensions/nucleus-ui/index.js
@@ -1,7 +1,17 @@
 export default function register({ init }) {
   init('routes', ({ app }) => {
     app.get('/core/theme.css', (_req, res) => {
-      res.type('text/css').send(':root { }');
+      const primary = process.env.THEME_PRIMARY ?? '#0070f3';
+      const background = process.env.THEME_BG ?? '#ffffff';
+      const css = `
+        :root {
+          --primary-color: ${primary};
+          --bg-color: ${background};
+        }
+        body { background-color: var(--bg-color); }
+        button { background-color: var(--primary-color); color: #fff; }
+      `;
+      res.type('text/css').send(css);
     });
   });
 }

--- a/loops/open-closed-loop_pass71.md
+++ b/loops/open-closed-loop_pass71.md
@@ -1,0 +1,5 @@
+## Pass 71
+- Evaluated all extensions using check_extensions.cjs.
+- Detected placeholder CSS in nucleus-ui.
+- Implemented env-driven theme variables and added unit test.
+- npm test still fails in @directus/api with exit code 129.

--- a/tests/nucleus-ui/package.json
+++ b/tests/nucleus-ui/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/tests/nucleus-ui/ui.test.mjs
+++ b/tests/nucleus-ui/ui.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import register from '../../extensions/nucleus-ui/index.js';
+
+let route;
+const init = (_n, fn) => fn({ app: { get: (_p, cb) => { route = cb; } } });
+process.env.THEME_PRIMARY = '#123456';
+process.env.THEME_BG = '#654321';
+register({ init });
+
+test('theme css uses env vars', async () => {
+  let mime; let text;
+  const res = { type: (m) => { mime = m; return res; }, send: (t) => { text = t; } };
+  route({}, res);
+  assert.equal(mime, 'text/css');
+  assert.ok(text.includes('--primary-color: #123456'));
+  assert.ok(text.includes('--bg-color: #654321'));
+});

--- a/todo.md
+++ b/todo.md
@@ -72,3 +72,4 @@
 - [pass68] Trust mise config to remove warnings and update docs {status:done} {priority:low}
 - [pass69] Replace placeholders in extensions with minimal routes; npm test fails (ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)
 - [pass70] Document CRM folder as legacy; tests still failing
+- [pass71] Add env-based theme support to nucleus-ui {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -714,9 +714,7 @@
       "changelog.md"
     ],
     "trigger": "lynx role tests"
-
-  }
-  ,
+  },
   {
     "pass": 69,
     "files": [
@@ -734,8 +732,8 @@
       "todo.md"
     ],
     "trigger": "verify extensions and add minimal routes"
-  }
-,  {
+  },
+  {
     "pass": 70,
     "files": [
       "loops/open-closed-loop_pass70.md",
@@ -748,5 +746,17 @@
       "todo.md"
     ],
     "trigger": "document CRM as legacy"
+  },
+  {
+    "pass": 71,
+    "files": [
+      "extensions/nucleus-ui/index.js",
+      "tests/nucleus-ui/ui.test.mjs",
+      "tests/nucleus-ui/package.json",
+      "loops/open-closed-loop_pass71.md",
+      "changelog.md",
+      "todo.md"
+    ],
+    "trigger": "add theme env css"
   }
 ]


### PR DESCRIPTION
## Summary
- support env-driven theme variables in `nucleus-ui` extension
- add unit test for the theme route
- document the pass in changelog and todo

## Testing
- `pnpm install`
- `npm test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @directus/app@13.11.3 build)*

------
https://chatgpt.com/codex/tasks/task_e_6872e82f0cf0832491f9dd538b82b447