### PR TITLE
Add README for Keycloak extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -442,3 +442,6 @@
 - Implemented minimal logic for CRM, DMARC, Contracts, Tenable and Sophos extensions.
 - Updated README docs accordingly.
 - npm test fails in @directus/app (ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL).
+\n## Phase 3 – Pass 76 (2025-09-10)
+- Added README for Keycloak auth extension.
+- npm test fails in @directus/api due to isolated-vm module error.

--- a/extensions/auth/keycloak/README.md
+++ b/extensions/auth/keycloak/README.md
@@ -1,0 +1,3 @@
+# Keycloak Auth Extension
+
+Provides OAuth2 login using Keycloak. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID`, and `KEYCLOAK_CLIENT_SECRET` environment variables. The extension overrides the Directus login to exchange user credentials for a Keycloak token and then logs into Directus using that access token.

--- a/todo.md
+++ b/todo.md
@@ -77,3 +77,4 @@
 - [pass73] Include custom extensions in pnpm workspace and reinstall deps {status:done} {priority:medium}
 - [pass74] Add README files for all extensions {status:done} {priority:low}
 - [pass75] Replace placeholder routes with minimal logic {status:done} {priority:low}
+- [pass76] Added Keycloak README; npm tests still failing (isolated-vm) {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -786,5 +786,12 @@
     "loop_history": [
       75
     ]
+  },
+  {
+    "pass": 76,
+    "files": [
+      "extensions/auth/keycloak/README.md"
+    ],
+    "trigger": "add missing keycloak README"
   }
 ]


### PR DESCRIPTION
## Summary
- add missing docs for `extensions/auth/keycloak`
- record the change in `changelog.md`, `todo.md`, and `trace.json`

## Testing
- `pnpm install --ignore-scripts`
- `npm test` *(fails: MODULE_NOT_FOUND isolated-vm)*

------
https://chatgpt.com/codex/tasks/task_e_68736a70c7c08324a25caafd4f8864c0