### PR TITLE
Add suppliers extension and contract termination

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -448,3 +448,13 @@
 \n## Phase 3 – Pass 77 (2025-09-10)
 - Evaluated extensions; all contain working minimal logic and READMEs.
 - npm test fails in @directus/api due to Axios 503 error.
+\n## Phase 3 – Pass 78 (2025-09-10)
+- Added supplier model and API endpoints with tests.
+- Added contract termination route and test.
+
+## Phase 3 – Pass 79 (2025-09-10)
+- Replaced CRM supplier API with new `nucleus-suppliers` extension.
+- Added contract termination route to `nucleus-contracts` extension.
+- Removed legacy supplier code from CRM backend.
+\n## Phase 3 – Pass 80 (2025-09-10)
+- Fixed malformed entry in trace.json and confirmed supplier extension wiring.

--- a/extensions/nucleus-contracts/index.js
+++ b/extensions/nucleus-contracts/index.js
@@ -15,5 +15,16 @@ export default function register({ init }) {
       contracts.push({ id, name });
       res.json({ id, name });
     });
+
+    app.post('/contracts/:id/terminate', (req, res) => {
+      const contract = contracts.find(
+        (c) => c.id === Number.parseInt(req.params.id, 10)
+      );
+      if (!contract) {
+        return res.status(404).json({ error: 'not found' });
+      }
+      contract.status = 'terminated';
+      res.json({ id: contract.id, status: contract.status });
+    });
   });
 }

--- a/extensions/nucleus-suppliers/README.md
+++ b/extensions/nucleus-suppliers/README.md
@@ -1,0 +1,3 @@
+# Nucleus Suppliers Extension
+
+Adds a simple suppliers API. Use `POST /suppliers` with `{ "name": "Acme" }` to create a supplier and `GET /suppliers` to list all suppliers.

--- a/extensions/nucleus-suppliers/index.js
+++ b/extensions/nucleus-suppliers/index.js
@@ -1,0 +1,19 @@
+const suppliers = [];
+
+export default function register({ init }) {
+  init('routes', ({ app }) => {
+    app.get('/suppliers', (_req, res) => {
+      res.json(suppliers);
+    });
+
+    app.post('/suppliers', (req, res) => {
+      const { name } = req.body ?? {};
+      if (!name) {
+        return res.status(400).json({ error: 'name required' });
+      }
+      const id = suppliers.length + 1;
+      suppliers.push({ id, name });
+      res.json({ id, name });
+    });
+  });
+}

--- a/extensions/nucleus-suppliers/package.json
+++ b/extensions/nucleus-suppliers/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-suppliers",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1040,6 +1040,8 @@ importers:
 
   extensions/nucleus-sophos: {}
 
+  extensions/nucleus-suppliers: {}
+
   extensions/nucleus-support: {}
 
   extensions/nucleus-tenable: {}
@@ -2271,6 +2273,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
 
+  tests/nucleus-contracts: {}
+
   tests/nucleus-docs:
     dependencies:
       csv-stringify:
@@ -2288,6 +2292,8 @@ importers:
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
+
+  tests/nucleus-suppliers: {}
 
   tests/nucleus-ui: {}
 

--- a/tests/nucleus-contracts/package.json
+++ b/tests/nucleus-contracts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nucleus-contracts-test",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {"test": "node test.mjs"}
+}

--- a/tests/nucleus-contracts/test.mjs
+++ b/tests/nucleus-contracts/test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import register from '../../extensions/nucleus-contracts/index.js';
+
+let createRoute; let termRoute;
+const init = (_n, fn) => {
+  fn({
+    app: {
+      post: (p, cb) => {
+        if (p === '/contracts') createRoute = cb;
+        if (p === '/contracts/:id/terminate') termRoute = cb;
+      },
+      get: () => {},
+    },
+  });
+};
+
+register({ init });
+
+test('terminate contract', () => {
+  const createRes = { json: (d) => { createRes.data = d; }, status: () => createRes };
+  createRoute({ body: { name: 'Deal' } }, createRes);
+  const id = createRes.data.id;
+  const termRes = { json: (d) => { termRes.data = d; }, status: (c) => { termRes.code = c; return termRes; } };
+  termRoute({ params: { id: String(id) } }, termRes);
+  assert.equal(termRes.data.status, 'terminated');
+});

--- a/tests/nucleus-suppliers/package.json
+++ b/tests/nucleus-suppliers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nucleus-suppliers-test",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test.mjs"
+  }
+}

--- a/tests/nucleus-suppliers/test.mjs
+++ b/tests/nucleus-suppliers/test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import register from '../../extensions/nucleus-suppliers/index.js';
+
+let postRoute;
+let getRoute;
+const init = (_n, fn) => {
+  fn({
+    app: {
+      post: (p, cb) => { if (p === '/suppliers') postRoute = cb; },
+      get: (p, cb) => { if (p === '/suppliers') getRoute = cb; },
+    },
+  });
+};
+
+register({ init });
+
+test('create and list suppliers', () => {
+  const postRes = { json: (d) => { postRes.data = d; }, status: () => postRes };
+  postRoute({ body: { name: 'Test' } }, postRes);
+  assert.equal(postRes.data.name, 'Test');
+  const listRes = { json: (d) => { listRes.data = d; } };
+  getRoute({}, listRes);
+  assert.ok(listRes.data.some((s) => s.id === postRes.data.id));
+});

--- a/todo.md
+++ b/todo.md
@@ -79,3 +79,4 @@
 - [pass75] Replace placeholder routes with minimal logic {status:done} {priority:low}
 - [pass76] Added Keycloak README; npm tests still failing (isolated-vm) {status:done} {priority:low}
 - [pass77] Review extensions for placeholders; tests failing due to Axios 503 {status:done} {priority:low}
+- [pass78] Implement supplier extension and contract termination {status:done} {priority:low}

--- a/trace.json
+++ b/trace.json
@@ -793,8 +793,7 @@
       "extensions/auth/keycloak/README.md"
     ],
     "trigger": "add missing keycloak README"
-  }
-,
+  },
   {
     "pass": 77,
     "files": [
@@ -802,5 +801,42 @@
       "todo.md"
     ],
     "trigger": "evaluated extensions and recorded failing tests"
+  },
+  {
+    "pass": 78,
+    "files": [
+      "CRM/backend/models/supplier.py",
+      "CRM/backend/routes/suppliers.py",
+      "CRM/backend/main.py",
+      "CRM/backend/routes/contracts.py",
+      "CRM/backend/models/__init__.py",
+      "CRM/backend/routes/__init__.py",
+      "CRM/tests/test_suppliers.py",
+      "CRM/tests/test_contracts.py",
+      "CRM/TODO.md",
+      "changelog.md"
+    ],
+    "trigger": "add suppliers and contract termination"
+  },
+  {
+    "pass": 79,
+    "files": [
+      "extensions/nucleus-suppliers/index.js",
+      "extensions/nucleus-suppliers/README.md",
+      "extensions/nucleus-suppliers/package.json",
+      "extensions/nucleus-contracts/index.js",
+      "tests/nucleus-suppliers/test.mjs",
+      "tests/nucleus-suppliers/package.json",
+      "tests/nucleus-contracts/test.mjs",
+      "tests/nucleus-contracts/package.json",
+      "CRM/backend/main.py",
+      "CRM/backend/models/__init__.py",
+      "CRM/backend/routes/__init__.py",
+      "CRM/backend/routes/contracts.py",
+      "CRM/tests/test_contracts.py",
+      "CRM/TODO.md",
+      "changelog.md"
+    ],
+    "trigger": "migrate supplier feature to extensions and add contract termination"
   }
 ]


### PR DESCRIPTION
## Summary
- move supplier API into new `nucleus-suppliers` extension
- add termination endpoint to `nucleus-contracts`
- delete legacy supplier code in CRM backend
- create node tests for new extensions
- document changes for pass 79
- fix trace.json formatting

## Testing
- `npm test` *(fails: @directus/api test exit 1)*
- `pytest -q CRM/tests`

------
https://chatgpt.com/codex/tasks/task_e_687377a247108324aaa201a5df4b6cf9